### PR TITLE
refactor(template)[OPENSCD-86]/UI refinement

### DIFF
--- a/apps/template-generator/src/App.svelte
+++ b/apps/template-generator/src/App.svelte
@@ -8,8 +8,9 @@
   import DefaultTypeView from './views/defaults/DefaultTypeView.svelte';
   import "svelte-material-ui/bare.css"
   import "../public/material-icon.css"
-  import "../public/global.css"
   import "../public/smui.css"
+  import "../public/global.css"
+  import "../../../libs/theme/src/lib/global.css"
 
   interface Props {
     devMode?: boolean;

--- a/apps/template-generator/src/views/lNodeTypeDetails/LNodeTypeDetailView.svelte
+++ b/apps/template-generator/src/views/lNodeTypeDetails/LNodeTypeDetailView.svelte
@@ -349,6 +349,7 @@
       onColumnActionClick={e => handleActionClick(e)}
       onItemEdit={({itemId, columnId}) => handleOnEdit(itemId, columnId)}
       onItemMarkChange={({itemId}) => handleToggleMark(itemId)}
+      onItemClick={({itemId}) => handleToggleMark(itemId)}
       onItemSelectChange={e => handleToggleSelect(e)}
       onItemDrop={e => handleItemDrop(e)}
       onItemApplyDefaults={e => handleApplyDefaults(e)}

--- a/apps/template-generator/src/views/lNodeTypeDetails/LNodeTypeDetailView.svelte
+++ b/apps/template-generator/src/views/lNodeTypeDetails/LNodeTypeDetailView.svelte
@@ -173,7 +173,7 @@
   }
 
   function handleOnEdit(itemId: string, columnId: string) {
-    setHomeTitle(`LN: ${lNodeTypeId}`);
+    setHomeTitle(`[LN] ${lNodeTypeId}`);
     const openMode: Mode = canEdit ? 'edit' : 'view';
     if (columnId === 'doTypes') {
       openDataObjectTypeDrawer(openMode, itemId);
@@ -235,7 +235,7 @@
   }
 
   function handleOnReferenceClick({itemId}) {
-    setHomeTitle(`LN: ${lNodeTypeId}`);
+    setHomeTitle(`[LN] ${lNodeTypeId}`);
     const ref = $refStore.find(i => i.name === itemId);
     openReferencedTypeDrawer(ref, 'view')
   }

--- a/apps/template-generator/src/views/lNodeTypeDetails/LNodeTypeDetailView.svelte
+++ b/apps/template-generator/src/views/lNodeTypeDetails/LNodeTypeDetailView.svelte
@@ -46,6 +46,7 @@
   import { getColumns } from './columns.config';
   import { createBreadcrumbs } from './lNodeTypeDetailsUtils';
   import { onMount } from 'svelte';
+  import { setHomeTitle } from '@oscd-transnet-plugins/oscd-services/drawer';
 
   // -----------------------------
   // Service instances
@@ -172,6 +173,7 @@
   }
 
   function handleOnEdit(itemId: string, columnId: string) {
+    setHomeTitle(`LN: ${lNodeTypeId}`);
     const openMode: Mode = canEdit ? 'edit' : 'view';
     if (columnId === 'doTypes') {
       openDataObjectTypeDrawer(openMode, itemId);
@@ -233,6 +235,7 @@
   }
 
   function handleOnReferenceClick({itemId}) {
+    setHomeTitle(`LN: ${lNodeTypeId}`);
     const ref = $refStore.find(i => i.name === itemId);
     openReferencedTypeDrawer(ref, 'view')
   }

--- a/apps/template-generator/src/views/lNodeTypeDetails/LNodeTypeDetailView.svelte
+++ b/apps/template-generator/src/views/lNodeTypeDetails/LNodeTypeDetailView.svelte
@@ -163,6 +163,7 @@
 
   // Dialog handlers
   function handleActionClick({ columnId }) {
+    setHomeTitle(`[LN] ${lNodeTypeId}`);
    if (columnId === 'doTypes') {
      openCreateDataObjectTypeDialog();
     } else if (columnId === 'daTypes') {

--- a/apps/template-generator/src/views/lNodeTypeDetails/LNodeTypeDetailView.svelte
+++ b/apps/template-generator/src/views/lNodeTypeDetails/LNodeTypeDetailView.svelte
@@ -315,6 +315,11 @@
         labelStyle="font-weight: bold; text-transform: uppercase; color: var(--mdc-theme-primary);"
       />
 
+      <OscdButton
+        disabled={!$isSavable} callback={() => editorStore.save()} variant="unelevated">
+        SAVE CHANGES
+      </OscdButton>
+      
       {#if $dirty}
         <OscdTooltip content="Save first to set as default" side="bottom" hoverDelay={300}>
           <SetDefaultButton onClick={() => handleClickOnSetAsDefault()} disabled={$dirty}/>
@@ -323,10 +328,6 @@
         <SetDefaultButton onClick={() => handleClickOnSetAsDefault()} />
       {/if}
 
-      <OscdButton
-        disabled={!$isSavable} callback={() => editorStore.save()} variant="unelevated">
-        SAVE CHANGES
-      </OscdButton>
 
       <OscdTooltip content="Type Actions" side="bottom" hoverDelay={2000}>
         <TypeActionMenu

--- a/apps/template-generator/src/views/lNodeTypeDetails/LNodeTypeDetailView.svelte
+++ b/apps/template-generator/src/views/lNodeTypeDetails/LNodeTypeDetailView.svelte
@@ -4,6 +4,7 @@
   // Services & utils
   import {
     applyDefaultWarningNotification,
+    assignOrCreateReference,
     type BasicType,
     type BasicTypes,
     canAssignTypeToObjectReference,
@@ -259,12 +260,22 @@
 
   async function handleRename() {
    const newTypeId = await handleRenameTypeWorkflow(DataTypeKind.LNodeType, lNodeTypeId);
-   console.log(newTypeId);
    if(newTypeId) {
      lNodeTypeId = newTypeId;
      loadLogicalNodeType(lNodeTypeId, lnClass)
    }
   }
+  
+  async function handleAddReference({itemId}) {
+    setHomeTitle(`[LN] ${lNodeTypeId}`);
+    assignOrCreateReference(
+      refStore,
+      DataTypeKind.LNodeType,
+      logicalNodeType.lnClass,
+      itemId
+    );
+  }
+
 
   // -----------------------------
   // Utils
@@ -356,6 +367,7 @@
       onItemApplyDefaults={e => handleApplyDefaults(e)}
       onItemUnlink={e => handleOnUnlink(e)}
       onItemReferenceClick={e => handleOnReferenceClick(e)}
+      onItemAddReferenceClick={e => handleAddReference(e)}
       onItemSetDefault={({itemId, columnId})  => handleOnSetAsDefault(itemId, columnId)}
     />
   </div>

--- a/libs/oscd-component/src/drawer-stack/DrawerBreadcrumbs.svelte
+++ b/libs/oscd-component/src/drawer-stack/DrawerBreadcrumbs.svelte
@@ -18,15 +18,15 @@
   }
 
   const visibleBreadcrumbs = $derived.by(() => {
-      if (breadcrumbs.length <= MAX_VISIBLE) {
-          // display all items
-          return breadcrumbs.map((label, index) => ({
-              label,
-              display: truncate(label),
-              truncated: label.length > TRUNCATE_AT,
-              isEllipsis: false,
-              isCurrent: index === breadcrumbs.length-1
-          }))
+    if (breadcrumbs.length <= MAX_VISIBLE) {
+        // display all items
+        return breadcrumbs.map((label, index) => ({
+            label,
+            display: truncate(label),
+            truncated: label.length > TRUNCATE_AT,
+            isEllipsis: false,
+            isCurrent: index === breadcrumbs.length-1
+        }))
       }
 
       const first = breadcrumbs[0];

--- a/libs/oscd-component/src/drawer-stack/DrawerBreadcrumbs.svelte
+++ b/libs/oscd-component/src/drawer-stack/DrawerBreadcrumbs.svelte
@@ -1,0 +1,112 @@
+<script lang=ts>
+  import OscdTooltip from "../oscd-tooltip/OscdTooltip.svelte";
+
+
+  interface Props {
+      breadcrumbs: string[]
+  }
+
+  const { breadcrumbs = []}: Props = $props();
+
+  const MAX_VISIBLE = 4;
+  const TRUNCATE_AT = 28;
+
+  function truncate(label: string) {
+      return label.length > TRUNCATE_AT
+      ? label.slice(0, TRUNCATE_AT) + "…"
+      : label;
+  }
+
+  const visibleBreadcrumbs = $derived.by(() => {
+      if (breadcrumbs.length <= MAX_VISIBLE) {
+          // display all items
+          return breadcrumbs.map((label, index) => ({
+              label,
+              display: truncate(label),
+              truncated: label.length > TRUNCATE_AT,
+              isEllipsis: false,
+              isCurrent: index === breadcrumbs.length-1
+          }))
+      }
+
+      const first = breadcrumbs[0];
+      const parents = breadcrumbs.slice(-3,-1);
+      const current = breadcrumbs[breadcrumbs.length-1];
+
+      return [
+          { label: first, display: truncate(first), truncated: first.length > TRUNCATE_AT, isEllipsis: false, isCurrent: false },
+          { label: "…", display: "…", truncated: false, isEllipsis: true, isCurrent: false },
+          ...parents.map((label) => ({ label, display: truncate(label), truncated: label.length > TRUNCATE_AT, isEllipsis: false, isCurrent: false })),
+          { label: current, display: truncate(current), truncated: current.length > TRUNCATE_AT, isEllipsis: false, isCurrent: true }
+      ]
+  });
+
+</script>
+
+
+<nav class="breadcrumbs" aria-label="Breadcrumb">
+  {#each visibleBreadcrumbs as crumb, index}
+    <OscdTooltip content={crumb.label} side="bottom" disabled={!crumb.truncated} hoverDelay={150}>
+        <span
+        class="breadcrumb
+            {crumb.isCurrent ? 'current' : ''}
+            {crumb.isEllipsis ? 'ellipsis' : ''}"
+        aria-current={crumb.isCurrent ? 'page' : undefined}
+        >
+        {crumb.display}
+        </span>
+    </OscdTooltip>
+
+    {#if index < visibleBreadcrumbs.length - 1}
+      <span class="separator">/</span>
+    {/if}
+  {/each}
+</nav>
+
+<style>
+.breadcrumbs {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;                       
+  font-size: 1rem;                    
+  white-space: nowrap;
+  max-width: 100%;                    
+  overflow: hidden;                   
+  color: rgba(255, 255, 255, 0.75);   
+}
+
+.breadcrumb {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  cursor: default;                    
+  color: rgba(255, 255, 255, 0.65);   
+  flex-shrink: 1;                     
+  min-width: 0;                       
+  max-width: 200px;                   
+}
+
+.breadcrumb.current {
+  font-weight: 500;  
+  color: #fff;       
+  cursor: default;   
+  flex-shrink: 0;    
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  max-width: 200px;  
+}
+
+.breadcrumb.ellipsis {
+  color: rgba(255, 255, 255, 0.65);
+  flex-shrink: 1;                  
+  cursor: default;                 
+}
+
+.separator {
+  color: rgba(255, 255, 255, 0.5);  
+  margin: 0 0.25rem;                
+  flex-shrink: 0;                   
+}
+
+</style>

--- a/libs/oscd-component/src/drawer-stack/DrawerStack.svelte
+++ b/libs/oscd-component/src/drawer-stack/DrawerStack.svelte
@@ -108,10 +108,16 @@
     padding: 1rem;
   }
 
-  .drawer-header__actions {
+  .drawer-footer {
+    background: #fff;
+    padding: 8px 1.5rem;
+    border-top: 1px solid var(--mdc-theme-on-surface-divider-color, rgba(0, 0, 0, .12));
+  }
+
+  .drawer-footer__actions {
     display: flex;
     align-items: center;
-    justify-content: center;
+    justify-content: end;
     gap: 1rem;
   }
 
@@ -165,24 +171,8 @@
       in:fly={{ x: baseWidth + 200, duration: 200 }}
       out:fly={{ x: baseWidth + 200, duration: 200 }}
     >
+      <!-- Start: Drawer Header -->
       <div class="drawer-header">
-        <div class="drawer-header__actions">
-          <Button
-            variant="unelevated"
-            color="primary"
-            style="background: white;
-            color: var(--mdc-theme-primary, #ff3e00)"
-            onclick={() => closeDrawer('save')}
-          >Save & Close</Button>
-          <Button
-            variant="unelevated"
-            color="secondary"
-            style="
-            background: #6B9197;
-            color: white"
-            onclick={() => closeDrawer('cancel')}
-          >Cancel</Button>
-        </div>
 
 
         <div class="drawer-header__breadcrumbs">
@@ -193,9 +183,6 @@
 
           <span class="breadcrumb-current">{drawer.title}</span>
         </div>
-
-
-
         <OscdIconActionButton
           type="close"
           fillColor="white"
@@ -204,12 +191,34 @@
           tooltipSide="left"
         />
       </div>
+      <!-- End: Drawer Header -->
+
+      <!-- Start: Drawer Body -->
       <div class="drawer-body">
         <drawer.component
           {...drawer.props}
           bind:this={drawer.ref}
         />
       </div>
+      <!-- End: Drawer Body -->
+
+      <!-- Start: Drawer Footer -->
+       <div class="drawer-footer">
+        <div class="drawer-footer__actions">
+          <Button
+            variant="unelevated"
+            color="primary"
+            style="background: white;
+            color: var(--mdc-theme-primary, #ff3e00)"
+            onclick={() => closeDrawer('cancel')}
+          >Cancel</Button>
+          <Button
+            variant="unelevated"
+            onclick={() => closeDrawer('save')}
+          >Save & Close</Button>
+        </div>
+       </div>
+      <!-- End: Drawer Footer -->
     </div>
   {/each}
 </div>

--- a/libs/oscd-component/src/drawer-stack/DrawerStack.svelte
+++ b/libs/oscd-component/src/drawer-stack/DrawerStack.svelte
@@ -1,15 +1,27 @@
 <script lang="ts">
-  import { drawers, closeDrawer } from '@oscd-transnet-plugins/oscd-services/drawer';
+  import { drawers, closeDrawer, homeTitle } from '@oscd-transnet-plugins/oscd-services/drawer';
   import type { Drawer } from '@oscd-transnet-plugins/oscd-services/drawer';
   import { fly } from 'svelte/transition';
   import { onMount, onDestroy } from 'svelte';
   import { OscdIconActionButton } from '@oscd-transnet-plugins/oscd-component';
   import Button from '@smui/button';
+  import OscdTooltip from '../oscd-tooltip/OscdTooltip.svelte';
 
   let drawerList: Drawer[] = $derived($drawers);
   const widthStep = 45;
 
   let innerWidth = $state(window.innerWidth);
+
+  let breadcrumbs = $derived.by(() => {
+  const titles = $drawers.map(d => d.title).slice(0, $drawers.length-1);
+
+  if (titles.length < 3) {
+    return titles;
+  }
+
+  return ["...", ...titles.slice(-2)]; // last two titles
+});
+
 
   // update on resize
   function handleResize() {
@@ -138,11 +150,19 @@
 
   .breadcrumb-segment {
     color: rgba(255, 255, 255, 0.65);
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    max-width: 200px;
   }
 
   .breadcrumb-current {
     color: #fff;
     font-weight: 500;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    max-width: 200px;
   }
 </style>
 
@@ -176,12 +196,28 @@
 
 
         <div class="drawer-header__breadcrumbs">
-          {#each drawerList.slice(0, index) as d}
-            <span class="breadcrumb-segment">{d.title}</span>
+          {#if $homeTitle}
+            <OscdTooltip side="bottom" content={$homeTitle}>
+            <div style="display: flex; align-items: center; gap: 0.1re;">
+              <svg xmlns="http://www.w3.org/2000/svg" height="22px" viewBox="0 -960 960 960" width="22px" fill="rgba(255, 255, 255, 0.65)"><path d="M160-120v-480l320-240 320 240v480H560v-280H400v280H160Z"/></svg>
+              <div class="breadcrumb-segment">
+                {$homeTitle}
+              </div>
+            </div>
+            </OscdTooltip>
+            <span class="breadcrumb-separator">›</span>
+          {/if}
+
+          {#each breadcrumbs as title, index (index)}
+            <OscdTooltip side="bottom" content={title}>
+              <div class="breadcrumb-segment">{title}</div>
+            </OscdTooltip>
             <span class="breadcrumb-separator">›</span>
           {/each}
 
-          <span class="breadcrumb-current">{drawer.title}</span>
+          <OscdTooltip side="bottom" content={drawer.title}>
+            <div class="breadcrumb-current">{drawer.title}</div>
+          </OscdTooltip>
         </div>
         <OscdIconActionButton
           type="close"

--- a/libs/oscd-component/src/drawer-stack/DrawerStack.svelte
+++ b/libs/oscd-component/src/drawer-stack/DrawerStack.svelte
@@ -6,6 +6,7 @@
   import { OscdIconActionButton } from '@oscd-transnet-plugins/oscd-component';
   import Button from '@smui/button';
   import OscdTooltip from '../oscd-tooltip/OscdTooltip.svelte';
+  import DrawerBreadcrumbs from './DrawerBreadcrumbs.svelte';
 
   let drawerList: Drawer[] = $derived($drawers);
   const widthStep = 45;
@@ -13,13 +14,8 @@
   let innerWidth = $state(window.innerWidth);
 
   let breadcrumbs = $derived.by(() => {
-  const titles = $drawers.map(d => d.title).slice(0, $drawers.length-1);
-
-  if (titles.length < 3) {
-    return titles;
-  }
-
-  return ["...", ...titles.slice(-2)]; // last two titles
+    const drawerTitles = $drawers.map(d => d.title);
+    return [$homeTitle, ...drawerTitles]
 });
 
 
@@ -143,27 +139,6 @@
     white-space: nowrap;
     text-overflow: ellipsis;
   }
-
-  .breadcrumb-separator {
-    color: rgba(255, 255, 255, 0.5);
-  }
-
-  .breadcrumb-segment {
-    color: rgba(255, 255, 255, 0.65);
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    max-width: 200px;
-  }
-
-  .breadcrumb-current {
-    color: #fff;
-    font-weight: 500;
-    white-space: nowrap;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    max-width: 200px;
-  }
 </style>
 
 <div class="drawer-stack">
@@ -196,29 +171,9 @@
 
 
         <div class="drawer-header__breadcrumbs">
-          {#if $homeTitle}
-            <OscdTooltip side="bottom" content={$homeTitle}>
-            <div style="display: flex; align-items: center; gap: 0.1re;">
-              <svg xmlns="http://www.w3.org/2000/svg" height="22px" viewBox="0 -960 960 960" width="22px" fill="rgba(255, 255, 255, 0.65)"><path d="M160-120v-480l320-240 320 240v480H560v-280H400v280H160Z"/></svg>
-              <div class="breadcrumb-segment">
-                {$homeTitle}
-              </div>
-            </div>
-            </OscdTooltip>
-            <span class="breadcrumb-separator">›</span>
-          {/if}
-
-          {#each breadcrumbs as title, index (index)}
-            <OscdTooltip side="bottom" content={title}>
-              <div class="breadcrumb-segment">{title}</div>
-            </OscdTooltip>
-            <span class="breadcrumb-separator">›</span>
-          {/each}
-
-          <OscdTooltip side="bottom" content={drawer.title}>
-            <div class="breadcrumb-current">{drawer.title}</div>
-          </OscdTooltip>
+          <DrawerBreadcrumbs {breadcrumbs}/>
         </div>
+
         <OscdIconActionButton
           type="close"
           fillColor="white"

--- a/libs/oscd-component/src/oscd-action-button/OscdActionButton.svelte
+++ b/libs/oscd-component/src/oscd-action-button/OscdActionButton.svelte
@@ -4,7 +4,7 @@
 
   interface Props {
     onClick?: () => void;
-    variant?: 'text' | 'outlined' | 'raised' | 'unelevated';
+    variant?: 'text' | 'outlined' | 'raised' | 'unelevated' | 'default';
   }
 
   let { onClick = () => {}, variant='unelevated'}: Props  = $props();
@@ -14,6 +14,7 @@
     onclick={onClick}
     class="button-shape-round"
     variant={variant}
+    style={variant === 'default' ? 'background: white;' : '' }
   >
-    <OscdMoreVertIcon svgStyles={variant === 'text' || variant === 'outlined' ? 'fill: var(--primary-base)' : ''}/>
+    <OscdMoreVertIcon svgStyles={variant === 'text' || variant === 'outlined' || variant === 'default' ? 'fill: var(--primary-base)' : ''}/>
   </Button>

--- a/libs/oscd-component/src/oscd-action-menu/OscdActionMenu.svelte
+++ b/libs/oscd-component/src/oscd-action-menu/OscdActionMenu.svelte
@@ -10,7 +10,7 @@
 
   interface Props {
     anchorCorner?: string;
-    buttonVariant?: 'text' | 'outlined' | 'raised' | 'unelevated';
+    buttonVariant?: 'text' | 'outlined' | 'raised' | 'unelevated' | 'default';
     children: Snippet<[any]>;
   }
 

--- a/libs/oscd-component/src/oscd-tooltip/OscdTooltip.svelte
+++ b/libs/oscd-component/src/oscd-tooltip/OscdTooltip.svelte
@@ -8,6 +8,7 @@
     hoverDelay?: number;
     transitionDuration?: number;
     children?: import('svelte').Snippet;
+    disabled: boolean;
   }
 
   let {
@@ -15,7 +16,8 @@
     side = "top",
     hoverDelay = 0,
     transitionDuration = 80,
-    children
+    children,
+    disabled = false
   }: Props = $props();
 
   const id = `tt-${Math.random().toString(36).slice(2)}`;
@@ -29,7 +31,7 @@
 
   // --- Hover / focus handlers ---
   function handleMouseEnter() {
-    if (!content) return;
+    if (!content || disabled) return;
     if (hoverDelay > 0) {
       hoverTimeout = setTimeout(() => show = true, hoverDelay);
     } else {
@@ -44,7 +46,7 @@
 
   // --- Position tooltip relative to trigger ---
   function updateTooltipPosition() {
-    if (!tooltipEl || !bubbleEl || !triggerEl) return;
+    if (!tooltipEl || !bubbleEl || !triggerEl || disabled) return;
     const rect = triggerEl.getBoundingClientRect();
     const tooltipRect = bubbleEl.getBoundingClientRect();
     let top = 0;
@@ -90,7 +92,7 @@
   onDestroy(destroyTooltip);
 
   $effect(() => {
-    if (!show || !content) {
+    if (!show || !content || disabled) {
       return;
     }
 
@@ -202,7 +204,7 @@
 <span
   bind:this={triggerEl}
   role="tooltip"
-  aria-describedby={content ? id : undefined}
+  aria-describedby={content && !disabled ? id : undefined}
   aria-labelledby="tooltip"
   onmouseenter={handleMouseEnter}
   onmouseleave={handleMouseLeave}

--- a/libs/oscd-icons/src/index.ts
+++ b/libs/oscd-icons/src/index.ts
@@ -20,13 +20,14 @@ export { default as OscdChevronLeftIcon } from './oscd-chevron-left-icon/OscdChe
 export { default as OscdArrowUpIcon } from './oscd-arrow-up-icon/OscdArrowUpIcon.svelte';
 export { default as OscdArrowDownIcon } from './oscd-arrow-down-icon/OscdArrowDownIcon.svelte';
 export { default as OscdWandStarsIcon } from './oscd-wand-stars-icon/OscdWandStarsIcon.svelte';
-export { default as OscdLinkOffIcon } from './oscd-link-off-icon/OscdLinkOffItem.svelte'
-export { default as OscdLockIcon } from './oscd-lock-icon/OscdLockIcon.svelte'
-export {default as OscdCallMadeIcon} from './oscd-call-made-icon/OscdCallMadeIcon.svelte'
-export {default as OscdCloseIcon} from './oscd-close-icon/OscdCloseIcon.svelte'
-export {default as OscdStarIcon} from './oscd-star-icon/OscdStarIcon.svelte'
-export { default as OscdAddCircleIcon } from './oscd-add-circle-icon/OscdAddCircleIcon.svelte'
-export { default as OscdCompareArrowsIcon } from './oscd-compare-arrows-icon/OscdCompareArrowsIcon.svelte'
-export { default as OscdDragHandleIcon } from './oscd-drag-handle-icon/OscdDragHandleIcon.svelte'
-export { default as OscdDragIndicatorIcon } from './oscd-drag-indicator-icon/OscdDragIndicatorIcon.svelte'
-export { default as OscdMoreVertIcon } from './oscd-more-vert-icon/OscdMoreVertIcon.svelte'
+export { default as OscdLinkOffIcon } from './oscd-link-off-icon/OscdLinkOffItem.svelte';
+export { default as OscdLockIcon } from './oscd-lock-icon/OscdLockIcon.svelte';
+export {default as OscdCallMadeIcon} from './oscd-call-made-icon/OscdCallMadeIcon.svelte';
+export {default as OscdCloseIcon} from './oscd-close-icon/OscdCloseIcon.svelte';
+export {default as OscdStarIcon} from './oscd-star-icon/OscdStarIcon.svelte';
+export { default as OscdAddCircleIcon } from './oscd-add-circle-icon/OscdAddCircleIcon.svelte';
+export { default as OscdCompareArrowsIcon } from './oscd-compare-arrows-icon/OscdCompareArrowsIcon.svelte';
+export { default as OscdDragHandleIcon } from './oscd-drag-handle-icon/OscdDragHandleIcon.svelte';
+export { default as OscdDragIndicatorIcon } from './oscd-drag-indicator-icon/OscdDragIndicatorIcon.svelte';
+export { default as OscdMoreVertIcon } from './oscd-more-vert-icon/OscdMoreVertIcon.svelte';
+export { default as OscdHomeIcon } from './oscd-home-icon/OscdHomeIcon.svelte';

--- a/libs/oscd-icons/src/oscd-home-icon/OscdHomeIcon.svelte
+++ b/libs/oscd-icons/src/oscd-home-icon/OscdHomeIcon.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+import OscdIconBase from '../oscd-icon-base/OscdIconBase.svelte';
+
+    interface Props {
+        svgStyles?: string;
+    }
+
+    let { svgStyles = '' }: Props = $props();
+</script>
+
+<OscdIconBase>
+    <svg style={svgStyles} xmlns="http://www.w3.org/2000/svg" viewBox="0 -960 960 960">
+        <path d="M160-120v-480l320-240 320 240v480H560v-280H400v280H160Z"/>
+    </svg>
+</OscdIconBase>

--- a/libs/oscd-services/src/drawer/drawerStackStore.ts
+++ b/libs/oscd-services/src/drawer/drawerStackStore.ts
@@ -44,6 +44,14 @@ export const drawers: Readable<Drawer[]> = {
   subscribe: drawerStore.subscribe
 };
 
+const _homeTitle = writable<string | undefined>(undefined);
+export const homeTitle: Readable<string | undefined> = {
+  subscribe: _homeTitle.subscribe
+}
+export function setHomeTitle(homeTitle: string) {
+  _homeTitle.update(_ => homeTitle)
+}
+
 /**
  * Open a new drawer by pushing it to the stack.
  */

--- a/libs/oscd-template-generator/src/lib/components/TypeHeader.svelte
+++ b/libs/oscd-template-generator/src/lib/components/TypeHeader.svelte
@@ -95,6 +95,14 @@
   <!-- Right side: actions -->
   <div class="actions-section">
     {#if instanceType}
+      <OscdSwitch
+        bind:checked={isEditMode}
+        onChange={e => handleChange(e)}
+        preventToggleOnClick={true}
+        id={`edit-mode-switch-${typeId}`}
+        label="Edit Mode"
+        labelStyle="font-weight: bold; text-transform: uppercase; color: var(--mdc-theme-primary);"
+      />
       {#if showSetAsDefault}
         {#if setAsDefaultDisabled}
           <OscdTooltip content="Save first to set as default" side="bottom" hoverDelay={300}>
@@ -104,14 +112,6 @@
           <SetDefaultButton onClick={onClickDefault} />
         {/if}
       {/if}
-    <OscdSwitch
-      bind:checked={isEditMode}
-      onChange={e => handleChange(e)}
-      preventToggleOnClick={true}
-      id={`edit-mode-switch-${typeId}`}
-      label="Edit Mode"
-      labelStyle="font-weight: bold; text-transform: uppercase; color: var(--mdc-theme-primary);"
-    />
     {:else}
       <Button variant="unelevated" color="primary" onclick={handleInstanceTypeSelect}>Choose {getInstanceText(type)} to Edit</Button>
     {/if}

--- a/libs/oscd-template-generator/src/lib/components/dialogs/AddReferenceDialog.svelte
+++ b/libs/oscd-template-generator/src/lib/components/dialogs/AddReferenceDialog.svelte
@@ -1,0 +1,187 @@
+<script lang=ts>
+  import Radio from '@smui/radio';
+  import FormField from "@smui/form-field";
+  import OscdBaseDialog from "libs/oscd-component/src/oscd-dialog/OscdBaseDialog.svelte";
+  import { getDataTypeService, getDefaultTypeService } from '../../services';
+  import Autocomplete from '@smui-extra/autocomplete';
+  import CreateTypeForm from '../forms/CreateTypeForm.svelte';
+  import { onMount } from 'svelte';
+  import OscdInfoIcon from 'libs/oscd-icons/src/oscd-info-icon/OscdInfoIcon.svelte';
+  import { closeDialog } from '@oscd-transnet-plugins/oscd-services/dialog';
+  import type { ChangeEventDetails } from '../forms/types';
+
+  type Mode = 'select' | 'create'
+
+  interface Item {
+    id: string
+  }
+
+  const service = getDataTypeService();
+  const defaultTypeService = getDefaultTypeService();
+
+  let {
+    open = $bindable(false),
+    typeKind,
+    instanceType,
+    objTypeKind,
+    objInstanceType,
+    itemId
+  } = $props();
+
+  let selectAutocompleteEl: HTMLElement = $state();
+
+  let mode: Mode  = $state('select');
+  let selectedItem = $state<Item>();
+  let loading = $state(true)
+  let options = $state([]);
+  let selectNotAvailable = $derived(options.length === 0)
+  let formState = $state<ChangeEventDetails | undefined>();
+
+onMount(async () => {
+    if (mode !== 'select') return;
+
+    loading = true;
+    try {
+      const types = await service.getAssignableTypes(typeKind, instanceType, [itemId]);
+      options = [
+        ...types.lNodeTypes,
+        ...types.dataObjectTypes,
+        ...types.dataAttributeTypes,
+        ...types.enumTypes
+      ].map((type) => ({ id: type.id }));
+
+      // auto-switch to create if no options
+      if (options.length === 0) {
+        mode = 'create';
+        return;
+      } 
+
+      // focus autocomplete
+      setTimeout(() => selectAutocompleteEl?.focus(), 350);
+    } catch (err) {
+      console.error('Error fetching types:', err);
+    } finally {
+      loading = false;
+    }
+  });
+
+  function handleConfirm() {
+    let result = {};
+    if (mode === 'select') {
+      result =  {
+        id: selectedItem.id,
+        instanceType: objInstanceType,
+        mode: mode
+      }
+    } else if (mode === 'create') {
+      result = {
+        id: formState.id,
+        instanceType: formState.selectedItem.id,
+        createFromDefault: formState.createFromDefault,
+        mode: mode
+      }
+    }
+
+    closeDialog('confirm', result)
+  }
+
+  function updateState(details: ChangeEventDetails) {
+    formState = details;
+  }
+
+  // ===== Event Handlers =====
+  function handleCreate() {
+    if(!formState || !formState.valid) return;
+    handleConfirm();
+  }
+</script>
+
+<div class="generic-create-dialog">
+  <OscdBaseDialog
+    title="Add Reference"
+    confirmActionText="ok"
+    maxWidth="800px"
+    bind:open
+    onCancel={() => closeDialog('cancel')}
+    onClose={() => closeDialog('exit')}
+    onConfirm={(() => handleConfirm())}
+  >
+    {#snippet content()}
+      <div style="padding: 1rem;" >
+        <div class="referencing-mode-radios">
+          <div class="radio-demo">
+            
+            <FormField>
+              <Radio bind:group={mode} value="select" touch disabled={selectNotAvailable}/>
+              {#snippet label()}
+                  Select 
+              {/snippet}
+            </FormField>
+            <FormField>
+              <Radio bind:group={mode} value="create" touch />
+              {#snippet label()}
+                  Create 
+              {/snippet}
+            </FormField>
+          </div>
+        </div>
+
+        {#if selectNotAvailable}
+          <p class="info-text">
+            <OscdInfoIcon svgStyles="fill: #555;"/> No compatible DataTypes available for this object.
+            Create a new DataType to continue.
+          </p>
+        {/if}
+
+        {#if mode === 'select' && !loading}
+          <Autocomplete
+            bind:this={selectAutocompleteEl}
+            label="Select Type"
+            bind:value={selectedItem}
+            {options}
+            getOptionLabel={o => o?.id ?? ''}
+          >
+            {#snippet match(item)}
+              <div>{item.id}</div>
+            {/snippet}
+          </Autocomplete>
+          
+        {:else if mode === 'create'}
+          <CreateTypeForm
+            idLabel = "Type ID"
+            autocompleteLabel="Instance Type"
+
+            typeKind={objTypeKind}
+            getOptions={() => service.getTypeOptions(objTypeKind)}
+
+            defaultInstance={objInstanceType}
+            typeSelectionDisabled={!!objInstanceType}
+
+            allowCreateFromDefault={false}
+            isDefaultAvailable={async (instanceType) => {
+                const result = await defaultTypeService.getDefault({instanceType, kind: objTypeKind});
+                return !!result;
+            }}
+
+            onSubmit={handleCreate}
+            onChange={updateState}
+          />
+        {:else}
+          unknown mode: {mode}
+        {/if}
+      </div>
+      {/snippet}
+  </OscdBaseDialog>
+</div>
+
+<style>
+    .info-text {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    color: #555;
+    font-size: 0.9rem;
+    margin-bottom: 1rem;
+  }
+</style>
+

--- a/libs/oscd-template-generator/src/lib/components/dialogs/AddReferenceDialog.svelte
+++ b/libs/oscd-template-generator/src/lib/components/dialogs/AddReferenceDialog.svelte
@@ -54,7 +54,7 @@ onMount(async () => {
       if (options.length === 0) {
         mode = 'create';
         return;
-      } 
+      }
 
       // focus autocomplete
       setTimeout(() => selectAutocompleteEl?.focus(), 350);
@@ -105,22 +105,23 @@ onMount(async () => {
     onCancel={() => closeDialog('cancel')}
     onClose={() => closeDialog('exit')}
     onConfirm={(() => handleConfirm())}
+    confirmDisabled={mode === 'select' ? !selectedItem : !(formState?.valid)}
   >
     {#snippet content()}
       <div style="padding: 1rem;" >
         <div class="referencing-mode-radios">
           <div class="radio-demo">
-            
+
             <FormField>
               <Radio bind:group={mode} value="select" touch disabled={selectNotAvailable}/>
               {#snippet label()}
-                  Select 
+                  Select
               {/snippet}
             </FormField>
             <FormField>
               <Radio bind:group={mode} value="create" touch />
               {#snippet label()}
-                  Create 
+                  Create
               {/snippet}
             </FormField>
           </div>
@@ -145,7 +146,7 @@ onMount(async () => {
               <div>{item.id}</div>
             {/snippet}
           </Autocomplete>
-          
+
         {:else if mode === 'create'}
           <CreateTypeForm
             idLabel = "Type ID"

--- a/libs/oscd-template-generator/src/lib/components/dialogs/CreateDialogs/GenericCreateDialog.svelte
+++ b/libs/oscd-template-generator/src/lib/components/dialogs/CreateDialogs/GenericCreateDialog.svelte
@@ -13,6 +13,10 @@
     idLabel?: string;
     autocompleteLabel?: string;
     typeKind: DataTypeKind;
+
+    defaultTypeId?: string;
+    defaultInstance?: string;
+
     getOptions?: () => Promise<TypeOption[]>;
     onConfirm: (id: string, selected: any, createFromDefault?: boolean) => void;
     checkDefaultAvailable?: (instanceType: string) => Promise<boolean>;
@@ -26,6 +30,10 @@
     idLabel = 'ID',
     autocompleteLabel = 'Select Option',
     typeKind,
+
+    defaultInstance,
+    defaultTypeId,
+
     getOptions = async () => [],
     onConfirm,
     checkDefaultAvailable =  async () => false,
@@ -76,6 +84,9 @@
         <CreateTypeForm
           {idLabel}
           typeKind={typeKind}
+
+          {defaultInstance}
+          {defaultTypeId}
 
           {autocompleteLabel}
           getOptions={getOptions}

--- a/libs/oscd-template-generator/src/lib/components/dialogs/CreateDialogs/NewDataAttributeTypeDialog.svelte
+++ b/libs/oscd-template-generator/src/lib/components/dialogs/CreateDialogs/NewDataAttributeTypeDialog.svelte
@@ -8,9 +8,11 @@
 
   interface Props {
     open?: boolean;
+    defaultTypeId?: string;
+    defaultInstance?: string;
   }
 
-  let { open = $bindable(false) }: Props = $props();
+  let { open = $bindable(false), defaultTypeId, defaultInstance }: Props = $props();
 
   const handleConfirm = (id: string, optionId: string) => {
     closeDialog('confirm', { id, instanceType: optionId});
@@ -21,6 +23,8 @@
 <GenericCreateDialog
   bind:open
   dialogTitle="Create Data Attribute Type"
+  {defaultTypeId}
+  {defaultInstance}
   confirmText="Next"
   idLabel="Data Attribute Type ID"
   autocompleteLabel="Data Attribute Instance"

--- a/libs/oscd-template-generator/src/lib/components/dialogs/CreateDialogs/NewDataObjectTypeDialog.svelte
+++ b/libs/oscd-template-generator/src/lib/components/dialogs/CreateDialogs/NewDataObjectTypeDialog.svelte
@@ -7,9 +7,12 @@
   const service = getDOTypeService();
   interface Props {
     open?: boolean;
+
+    defaultTypeId?: string;
+    defaultInstance?: string;
   }
 
-  let { open = $bindable(false) }: Props = $props();
+  let { open = $bindable(false), defaultInstance, defaultTypeId }: Props = $props();
 
   const handleConfirm = (id: string, optionId: string) => {
     closeDialog('confirm', { id, cdc: optionId });
@@ -19,6 +22,8 @@
 
 <GenericCreateDialog
   bind:open
+  {defaultInstance}
+  {defaultTypeId}
   dialogTitle="Create New Data Object Type"
   confirmText="Next"
   idLabel="ID"

--- a/libs/oscd-template-generator/src/lib/components/dialogs/CreateDialogs/NewEnumTypeDialog.svelte
+++ b/libs/oscd-template-generator/src/lib/components/dialogs/CreateDialogs/NewEnumTypeDialog.svelte
@@ -8,9 +8,11 @@
 
   interface Props {
     open?: boolean;
+    defaultTypeId?: string;
+    defaultInstance?: string;
   }
 
-  let { open = $bindable(false) }: Props = $props();
+  let { open = $bindable(false), defaultTypeId, defaultInstance }: Props = $props();
 
   const handleConfirm = (id: string, optionId: string) => {
     closeDialog('confirm', { id, instanceType: optionId});
@@ -20,6 +22,8 @@
 
 <GenericCreateDialog
   bind:open
+  {defaultTypeId}
+  {defaultInstance}
   dialogTitle="Create Enum Type"
   confirmText="Next"
   idLabel="Enum Type ID"

--- a/libs/oscd-template-generator/src/lib/components/drawers/daTypeDrawer/DaTypeDrawer.svelte
+++ b/libs/oscd-template-generator/src/lib/components/drawers/daTypeDrawer/DaTypeDrawer.svelte
@@ -14,6 +14,7 @@
   import { closeDrawer, type CloseReason } from '@oscd-transnet-plugins/oscd-services/drawer';
   import {
   applyDefaultWarningNotification,
+    assignOrCreateReference,
     canAssignTypeToObjectReference,
     getDisplayDataTypeItems,
     getDisplayReferenceItems,
@@ -220,6 +221,15 @@
     openReferencedTypeDrawer(ref, 'view');
   }
 
+  async function handleAddReference({itemId}) {
+    assignOrCreateReference(
+       refStore,
+       DataTypeKind.DAType,
+       dataAttributeTypes.instanceType,
+       itemId
+    );
+  }
+
   function handleActionClick({ columnId }) {
     if (columnId === 'dataAttributeTypes') openCreateDataAttributeTypeDialog();
     else if (columnId === 'enumTypes') openCreateEnumTypeDialog();
@@ -319,6 +329,7 @@
   onColumnActionClick={e => handleActionClick(e)}
   onItemEdit={e => handleOnEdit(e.itemId, e.columnId)}
   onItemReferenceClick={e => handleOnReferenceClick(e.itemId)}
+  onItemAddReferenceClick={(e) => handleAddReference(e)}
   onItemUnlink={({ itemId }) => refStore.removeTypeReference(itemId)}
   onItemSetDefault={({itemId, columnId})  => handleOnSetAsDefault(itemId, columnId)}
   onItemApplyDefaults={e => handleApplyDefaults(e)}

--- a/libs/oscd-template-generator/src/lib/components/drawers/daTypeDrawer/DaTypeDrawer.svelte
+++ b/libs/oscd-template-generator/src/lib/components/drawers/daTypeDrawer/DaTypeDrawer.svelte
@@ -312,6 +312,7 @@
 <TBoard
   {columns}
   data={boardData}
+  onItemClick={(e) => handleOnMark(e)}
   onItemMarkChange={e => handleOnMark(e)}
   onItemSelectChange={e => handleOnSelect(e)}
   onItemDrop={e => handleItemDrop(e)}

--- a/libs/oscd-template-generator/src/lib/components/drawers/doTypeDrawer/DoTypeDrawer.svelte
+++ b/libs/oscd-template-generator/src/lib/components/drawers/doTypeDrawer/DoTypeDrawer.svelte
@@ -16,6 +16,7 @@
   import { closeDrawer, type CloseReason } from '@oscd-transnet-plugins/oscd-services/drawer';
   import {
     applyDefaultWarningNotification,
+    assignOrCreateReference,
     canAssignTypeToObjectReference,
     getDisplayDataTypeItems,
     getDisplayReferenceItems,
@@ -226,6 +227,16 @@
     openReferencedTypeDrawer(ref, 'edit');
   }
 
+  async function handleAddReference({itemId}) {
+    assignOrCreateReference(
+       refStore,
+       DataTypeKind.DOType,
+       dataObjectType.cdc,
+       itemId
+    );
+  }
+
+
   function handleActionClick({ columnId }) {
     if (columnId === 'dataObjectTypes') {
       openCreateDataObjectTypeDialog();
@@ -312,6 +323,7 @@
   onItemDrop={(e) => handleItemDrop(e)}
   onItemEdit={({ itemId, columnId }) => handleOnEdit(itemId, columnId)}
   onItemReferenceClick={({ itemId}) => handleOnReferenceClick(itemId)}
+  onItemAddReferenceClick={(e) => handleAddReference(e)}
   onItemUnlink={({ itemId }) => refStore.removeTypeReference(itemId)}
   onColumnActionClick={({ columnId }) => handleActionClick({ columnId })}
   onItemSetDefault={({itemId, columnId})  => handleOnSetAsDefault(itemId, columnId)}

--- a/libs/oscd-template-generator/src/lib/components/drawers/doTypeDrawer/DoTypeDrawer.svelte
+++ b/libs/oscd-template-generator/src/lib/components/drawers/doTypeDrawer/DoTypeDrawer.svelte
@@ -306,6 +306,7 @@
 <TBoard
   {columns}
   data={boardData}
+  onItemClick={(e) => handleOnMark(e)}
   onItemMarkChange={(e) => handleOnMark(e)}
   onItemSelectChange={(e) => handleOnSelect(e)}
   onItemDrop={(e) => handleItemDrop(e)}

--- a/libs/oscd-template-generator/src/lib/components/forms/CreateTypeForm.svelte
+++ b/libs/oscd-template-generator/src/lib/components/forms/CreateTypeForm.svelte
@@ -12,6 +12,11 @@
     idLabel?: string;
     typeKind: DataTypeKind
 
+    // defaults
+    defaultTypeId?: string,
+    defaultInstance?: string,
+
+
     // auto complete settings
     autocompleteLabel?: string;
     getOptions?: () => Promise<Option[]>;
@@ -19,6 +24,8 @@
     // create from default settings
     allowCreateFromDefault?: boolean; // callbacks
     isDefaultAvailable?: (typeId: string) => Promise<boolean>;
+
+    typeSelectionDisabled?: boolean;
 
     onChange?: (event: ChangeEventDetails) => void;
     onSubmit?: (event: ChangeEventDetails) => void;
@@ -28,11 +35,16 @@
     idLabel = 'Enter Id',
     typeKind,
 
+    defaultTypeId = '',
+    defaultInstance,
+
     autocompleteLabel = 'Select Option',
     getOptions = async () => [],
 
     allowCreateFromDefault = false,
     isDefaultAvailable = async (_: string) => false,
+
+    typeSelectionDisabled = false,
 
     onChange = (_: ChangeEventDetails) => {
     },
@@ -40,14 +52,15 @@
     }
   }: Props = $props();
 
-  let inputEl = $state(undefined);
+  let idInputEl = $state(undefined);
+  let instanceTypeSelectEl = $state(undefined);
 
   // --- State ---
   let loading = $state<boolean>(false);
   let options = $state<Option[]>([]);
 
   // from fields
-  let typeId = $state<string>('');
+  let typeId = $state<string>(defaultTypeId);
   let selectedItem = $state<Option | undefined>(undefined);
   let createFromDefault = $state<boolean>(false);
 
@@ -59,21 +72,26 @@
   // default available for selected item
   let defaultAvailable = $state<boolean>(false);
 
-  onMount(() => {
-    loadOptions();
-     setTimeout(() => {
-      inputEl.focus();
-    }, 350)
+  onMount(async () => {
+    await loadOptions();
+    focusElement()
   });
 
-  function loadOptions() {
+  async function loadOptions() {
     loading = true;
-    getOptions().then((data) => {
+    try {
+      const data = await getOptions();
       options = data;
+
+      // preselect instance
+      if(defaultInstance) {
+        selectedItem = data.find(d => d.id === defaultInstance); // check if default is a valid option
+      }
+
       loading = false;
-    }).catch((err) => {
-      console.log('Error loading options:', err);
-    });
+    } catch (err) {
+      console.error('Error loading options:', err);
+    }
   }
 
   let getOptionLabel: (opt: Option) => string = (opt) => opt?.id ?? '';
@@ -86,6 +104,26 @@
       createFromDefault: createFromDefault,
       valid: isFormValid
     });
+  }
+
+  function focusElement() {
+     setTimeout(() => {
+      // if instance is selected, focus input
+      if (selectedItem) {
+        focusInput();
+      } else {
+        focusSelect();
+      }
+    }, 350) // delay focus to prevent other element to be focused later
+
+  }
+
+  function focusInput() {
+    idInputEl?.focus();
+  }
+
+  function focusSelect() {
+    instanceTypeSelectEl?.focus();
   }
 
   // dispatch if any input changes
@@ -121,8 +159,9 @@
     <Autocomplete
       label={autocompleteLabel}
       bind:value={selectedItem}
-      bind:this={inputEl}
+      bind:this={instanceTypeSelectEl}
       selectOnExactMatch
+      disabled={typeSelectionDisabled}
       {options}
       {getOptionLabel}
       textfield$required
@@ -141,9 +180,10 @@
   <TypeIdInput
     bind:typeId={typeId}
     bind:valid={isTypeIdValid}
+    bind:this={idInputEl}
     {typeKind}
     idLabel={idLabel}
-    showErrorsOnInput={false}
+    showErrorsOnInput={true}
   />
 
   {#if allowCreateFromDefault && !!selectedItem}

--- a/libs/oscd-template-generator/src/lib/components/forms/CreateTypeForm.svelte
+++ b/libs/oscd-template-generator/src/lib/components/forms/CreateTypeForm.svelte
@@ -40,7 +40,7 @@
     }
   }: Props = $props();
 
-  let inputEl;
+  let inputEl = $state(undefined);
 
   // --- State ---
   let loading = $state<boolean>(false);
@@ -116,19 +116,13 @@
 </script>
 
 <form onsubmit={handleSubmit}>
-  <TypeIdInput
-    bind:typeId={typeId}
-    bind:valid={isTypeIdValid}
-    bind:this={inputEl}
-    {typeKind}
-    idLabel={idLabel}
-    showErrorsOnInput={false}
-  />
 
   {#if !loading}
     <Autocomplete
       label={autocompleteLabel}
       bind:value={selectedItem}
+      bind:this={inputEl}
+      selectOnExactMatch
       {options}
       {getOptionLabel}
       textfield$required
@@ -143,6 +137,14 @@
       {/snippet}
     </Autocomplete>
   {/if}
+
+  <TypeIdInput
+    bind:typeId={typeId}
+    bind:valid={isTypeIdValid}
+    {typeKind}
+    idLabel={idLabel}
+    showErrorsOnInput={false}
+  />
 
   {#if allowCreateFromDefault && !!selectedItem}
     <div style="margin-top: 1em;">

--- a/libs/oscd-template-generator/src/lib/components/index.ts
+++ b/libs/oscd-template-generator/src/lib/components/index.ts
@@ -17,6 +17,7 @@ export {default as TypeRenameDialog } from './dialogs/TypeRenameDialog.svelte';
 export {default as NewDataObjectTypeDialog } from './dialogs/CreateDialogs/NewDataObjectTypeDialog.svelte';
 export {default as NewDataAttributeTypeDialog } from './dialogs/CreateDialogs/NewDataAttributeTypeDialog.svelte';
 export {default as NewEnumTypeDialog } from './dialogs/CreateDialogs/NewEnumTypeDialog.svelte';
+export {default as AddReferenceDialog } from './dialogs/AddReferenceDialog.svelte'
 
 
 export {default as LogicalNodeTypeRow} from './tables/LogicalNodeTypeRow.svelte';

--- a/libs/oscd-template-generator/src/lib/components/tboard/TBoard.svelte
+++ b/libs/oscd-template-generator/src/lib/components/tboard/TBoard.svelte
@@ -22,7 +22,8 @@
     onItemDragChange?: (event: EventDetails) => void;
     onItemMarkChange?: (event: { columnId: string, itemId: string; item: TItem; marked: boolean }) => void;
     onItemSelectChange?: (event: EventDetails) => void;
-    onItemReferenceClick?: (event: { columnId:string, itemId: string; item: TItem; reference: string }) => void;
+    onItemReferenceClick?: (event: { columnId: string, itemId: string; item: TItem; reference: string }) => void;
+    onItemAddReferenceClick?: (event: { columnId: string, itemId: string; item: TItem }) => void;
     onItemSetDefault?: (event: EventDetails) => void;
     onItemUnlink?: (event: EventDetails) => void;
     onItemEdit?: (event: EventDetails) => void;
@@ -41,6 +42,7 @@
     onItemMarkChange = () => {},
     onItemSelectChange = () => {},
     onItemReferenceClick = () => {},
+    onItemAddReferenceClick = () => {},
     onItemSetDefault = () => {},
     onItemUnlink = () => {},
     onItemEdit = () => {},
@@ -149,6 +151,7 @@
       onItemDragChange={e => handleOnItemDrag(column.id, e)}
       onItemDrop={e => handleItemDrop(column.id, e)}
       onItemReferenceClick={e => onItemReferenceClick({columnId: column.id, ...e})}
+      onItemAddReferenceClick={e => onItemAddReferenceClick({columnId: column.id, ...e})}
       onItemSetDefault={e => onItemSetDefault({columnId: column.id, ...e})}
     />
 

--- a/libs/oscd-template-generator/src/lib/components/tboard/TCard.svelte
+++ b/libs/oscd-template-generator/src/lib/components/tboard/TCard.svelte
@@ -111,7 +111,7 @@
         </OscdTooltip>
       {:else}
         <OscdTooltip content="Configure" hoverDelay={500}>
-          <Checkbox checked={selected} onchange={onSelectChange}/>
+          <Checkbox checked={selected} onchange={onSelectChange} onclick={e => e.stopPropagation()}/>
         </OscdTooltip>
       {/if}
     </div>

--- a/libs/oscd-template-generator/src/lib/components/tboard/TCard.svelte
+++ b/libs/oscd-template-generator/src/lib/components/tboard/TCard.svelte
@@ -45,7 +45,7 @@
     canEdit = false,
     canMark = false,
     canApplyDefaults = false,
-    canClick = true,
+    canClick = false,
     canUnlink = true,
     canClickReference = true,
     canSetDefault = false,

--- a/libs/oscd-template-generator/src/lib/components/tboard/TCard.svelte
+++ b/libs/oscd-template-generator/src/lib/components/tboard/TCard.svelte
@@ -45,7 +45,7 @@
     canEdit = false,
     canMark = false,
     canApplyDefaults = false,
-    canClick = false,
+    canClick = true,
     canUnlink = true,
     canClickReference = true,
     canSetDefault = false,
@@ -85,7 +85,7 @@
   function handleOnEdit() { if (canEdit) onEdit(); }
   function handleOnApplyDefaults() { if (canApplyDefaults) onApplyDefaults(); }
   function handleOnUnlink() { if (canUnlink) onUnlink(); }
-  function handleOnReferenceClick() { if (canClickReference) onReferenceClick(); }
+  function handleOnReferenceClick(e: Event) { e.stopPropagation(); if (canClickReference) onReferenceClick(); }
   function handleOnSetDefault() { if (canSetDefault) onSetDefault(); }
 
   let cardState= $derived(getCardState(isDragTarget, canDrop, selectionEnabled, isMandatory, selected));
@@ -93,7 +93,7 @@
 </script>
 
 <div
-  class="oscd-card-item {cardState}"
+  class="oscd-card-item {cardState} {canClick ? 'clickable' : ''}"
   class:marked={marked}
   class:is-over={isOver}
   class:error={(isMandatory || selected) && referencable && !subtitle && !isDragTarget}
@@ -185,7 +185,7 @@
   >
     {#if subtitle}
       <OscdTooltip content={subtitle} hoverDelay={500} side="right">
-        <button class="oscd-card-subtitle--with-tooltip" onclick={handleOnReferenceClick} class:pointer={canClickReference}>
+        <button class="oscd-card-subtitle--with-tooltip" onclick={e => handleOnReferenceClick(e)} class:pointer={canClickReference}>
           {#if canClickReference}
             <OscdCallMadeIcon fill={onPrimaryColor} size="15px" />
           {/if}
@@ -395,9 +395,11 @@
     white-space: nowrap;
   }
 
+  
   .clickable:hover {
-    background: rgba(0, 0, 0, 0.1);
     cursor: pointer;
+    filter: brightness(1.05); /* 5% brighter */
+    transition: filter 0.2s ease;
   }
 
   .oscd-card-chip {

--- a/libs/oscd-template-generator/src/lib/components/tboard/TCard.svelte
+++ b/libs/oscd-template-generator/src/lib/components/tboard/TCard.svelte
@@ -33,6 +33,7 @@
     onApplyDefaults?: () => void;
     onUnlink?: () => void;
     onReferenceClick?: () => void;
+    onAddReferenceClick?: () => void;
     onSetDefault?: () => void;
     onSelectChange?: () => void;
   }
@@ -65,6 +66,7 @@
     onApplyDefaults = () => {},
     onUnlink = () => {},
     onReferenceClick = () => {},
+    onAddReferenceClick = () => {},
     onSetDefault = () => {},
     onSelectChange = () => {},
   }: Props = $props();
@@ -192,11 +194,18 @@
           {subtitle.length > 25 ? subtitle.slice(0, 25) + '...' : subtitle}
         </button>
         </OscdTooltip>
-    {:else if (isMandatory ||selected) && !subtitle && referencable}
-      <OscdWarningIcon fill="#FF6B6B" size="15px" />
-      Add reference
-    {:else if !subtitle && referencable && !isMandatory && !selected}
-      Add reference
+    {:else if !subtitle && referencable}
+      <button 
+      class="oscd-card-subtitle__add-reference"
+      onclick={(e) => {
+        e.stopPropagation();
+        onAddReferenceClick();
+      }}>
+        {#if isMandatory || selected }
+          <OscdWarningIcon fill="#FF6B6B" size="15px" />
+        {/if}
+        Add reference
+      </button> 
     {/if}
   </span>
     {:else}
@@ -425,6 +434,18 @@
 
   .pointer {
     cursor: pointer;
+  }
+
+  .oscd-card-subtitle__add-reference {
+     all: unset;
+     cursor: pointer;
+     display: flex;
+     align-items: center;
+     gap: 0.1rem;
+  }
+
+  .oscd-card-subtitle__add-reference:hover {
+     cursor: pointer;
   }
 
   :global(.oscd-card-item .selection .oscd-icon svg) {

--- a/libs/oscd-template-generator/src/lib/components/tboard/TCardList.svelte
+++ b/libs/oscd-template-generator/src/lib/components/tboard/TCardList.svelte
@@ -21,6 +21,7 @@
     onItemMarkChange?: (event: { itemId: string; item: TItem; marked: boolean }) => void;
     onItemSelectChange?: (event: { itemId: string; item: TItem | null }) => void;
     onItemReferenceClick?: (event: { itemId: string; item: TItem; reference: string }) => void;
+    onItemAddReferenceClick?: (event: { itemId: string; item: TItem }) => void;
     onItemSetDefault?: (event: {itemId: string, item: TItem}) => void;
     onItemUnlink?: (event: {itemId: string, item: TItem}) => void;
     onItemEdit?: (event: {itemId: string, item: TItem}) => void;
@@ -42,6 +43,7 @@
     onItemMarkChange = () => {},
     onItemSelectChange = () => {},
     onItemReferenceClick = () => {},
+    onItemAddReferenceClick = () => {},
     onItemSetDefault = () => {},
     onItemUnlink = () => {},
     onItemEdit = () => {},
@@ -159,6 +161,7 @@
       onApplyDefaults={() => onItemApplyDefaults({itemId: item.id, item})}
       onUnlink={() => onItemUnlink({itemId: item.id, item})}
       onReferenceClick={(e) => onItemReferenceClick({item, itemId: item.id, reference: e})}
+      onAddReferenceClick={() => onItemAddReferenceClick({itemId: item.id, item})}
       onSetDefault={() => onItemSetDefault({itemId: item.id, item})}
     />
     </div>

--- a/libs/oscd-template-generator/src/lib/components/tboard/TCardList.svelte
+++ b/libs/oscd-template-generator/src/lib/components/tboard/TCardList.svelte
@@ -141,6 +141,7 @@
       showSelectionIndicator={showSelectionIndicator}
       canApplyDefaults={item.canApplyDefaults}
       canUnlink={item.canUnlink}
+      canClick={item.canClick}
       isDragTarget={isDragTarget(item, dropCandidate)}
       canDrop={isDroppable(item, dropCandidate)}
       canDrag={itemsDraggable}

--- a/libs/oscd-template-generator/src/lib/components/tboard/TColumn.svelte
+++ b/libs/oscd-template-generator/src/lib/components/tboard/TColumn.svelte
@@ -76,7 +76,9 @@
   function matchesQuery(item: TItem, query: string): boolean {
     const q = query.toLowerCase().trim();
 
-    return item.title.toLowerCase().includes(q) || item.subtitle?.toLowerCase().includes(q);
+    return item.title.toLowerCase().includes(q) || 
+      item.subtitle?.toLowerCase().includes(q)  ||
+      item.badgeText?.toLocaleLowerCase().includes(q);
   }
 
   function filterItems(itemsToFilter: TItem[], query: string): TItem[] {

--- a/libs/oscd-template-generator/src/lib/components/tboard/TColumn.svelte
+++ b/libs/oscd-template-generator/src/lib/components/tboard/TColumn.svelte
@@ -28,6 +28,7 @@
     onItemMarkChange?: (event: { itemId: string; item: TItem; marked: boolean }) => void;
     onItemSelectChange?: (event: { itemId: string; item: TItem | null }) => void;
     onItemReferenceClick?: (event: { itemId: string; item: TItem; reference: string }) => void;
+    onItemAddReferenceClick?: (evetn: { itemId: string; item: TItem}) => void;
     onItemSetDefault?: ({itemId: string, item: TItem}) => void;
     onItemUnlink?: ({itemId: string, item: TItem}) => void;
     onItemEdit?: ({itemId: string, item: TItem}) => void;
@@ -60,6 +61,7 @@
     onItemMarkChange = () => {},
     onItemSelectChange = () => {},
     onItemReferenceClick = () => {},
+    onItemAddReferenceClick = () => {},
     onItemSetDefault = () => {},
     onItemUnlink = () => {},
     onItemEdit = () => {},
@@ -133,6 +135,7 @@
     onItemDragChange={(e) => onItemDragChange(e)}
     onItemDrop={(e) => onItemDrop(e)}
     onItemReferenceClick={(e) => onItemReferenceClick(e)}
+    onItemAddReferenceClick={(e) => onItemAddReferenceClick(e)}
     onItemSetDefault={(e) => onItemSetDefault(e)}
   />
   </div>

--- a/libs/oscd-template-generator/src/lib/components/tboard/types.ts
+++ b/libs/oscd-template-generator/src/lib/components/tboard/types.ts
@@ -9,6 +9,7 @@ export type TItem = {
   selected?: boolean
   isMandatory?: boolean;
 
+  canClick?: boolean;
   canEdit?: boolean;
   canMark?: boolean;
   canSelect?: boolean;

--- a/libs/oscd-template-generator/src/lib/components/ui/SetDefaultButton.svelte
+++ b/libs/oscd-template-generator/src/lib/components/ui/SetDefaultButton.svelte
@@ -23,8 +23,8 @@ let iconStyles = $derived.by(() => {
 </script>
 <Button
   disabled={disabled}
-  color="primary"
-  variant="outlined"
+  variant="default"
+  style="background: white;"
   onclick={onClick}>
   <div style="margin-right: 0.2rem;"><OscdStarIcon svgStyles={iconStyles}/></div> Set as Default
 </Button>

--- a/libs/oscd-template-generator/src/lib/components/ui/TypeActionMenu.svelte
+++ b/libs/oscd-template-generator/src/lib/components/ui/TypeActionMenu.svelte
@@ -13,7 +13,7 @@ const { onRename = () => {}, onDelete = () => {} }: Props  = $props();
 
 </script>
 
-<OscdActionMenu buttonVariant="text">
+<OscdActionMenu buttonVariant="default">
   <List>
     <Item onSMUIAction={onRename}>
       <Graphic><OscdEditIcon svgStyles="fill: var(--primary-base)"/></Graphic>

--- a/libs/oscd-template-generator/src/lib/mappers/simpleTItem.mapper.ts
+++ b/libs/oscd-template-generator/src/lib/mappers/simpleTItem.mapper.ts
@@ -36,6 +36,7 @@ export function mapObjectReferenceStateToTItem(objRef: ObjectReferenceState, isE
     selected: objRef.meta.isConfigured,
     canEdit: false,
     canMark: false,
+    canClick: true,
     canSelect: isEditMode,
     canUnlink: isEditMode && !!objRef.typeRef && !objRef.meta.isMandatory,
     canApplyDefaults: isEditMode && objRef.meta.requiresReference,

--- a/libs/oscd-template-generator/src/lib/mappers/simpleTItem.mapper.ts
+++ b/libs/oscd-template-generator/src/lib/mappers/simpleTItem.mapper.ts
@@ -35,7 +35,7 @@ export function mapObjectReferenceStateToTItem(objRef: ObjectReferenceState, isE
     isMandatory: objRef.meta.isMandatory,
     selected: objRef.meta.isConfigured,
     canEdit: false,
-    canMark: objRef.meta.requiresReference,
+    canMark: false,
     canSelect: isEditMode,
     canUnlink: isEditMode && !!objRef.typeRef && !objRef.meta.isMandatory,
     canApplyDefaults: isEditMode && objRef.meta.requiresReference,

--- a/libs/oscd-template-generator/src/lib/stores/objectReferenceStore.ts
+++ b/libs/oscd-template-generator/src/lib/stores/objectReferenceStore.ts
@@ -24,6 +24,9 @@ export interface ObjectReferenceStore extends Readable<ObjectReferenceState[]> {
   /** Items that have been marked */
   markedItemIds: Readable<string[]>;
 
+  /** Returns the single marked item, or undefined if none is selected. */
+  markedItem: Readable<ObjectReferenceState | null>;
+
   /** Items that have been configured */
   configuredItems: Readable<ObjectReferenceState[]>;
 
@@ -111,6 +114,7 @@ export function createObjectReferenceStore(
 
   const markedItems = derived(store, $items => $items.filter(item => item.isMarked));
   const markedItemIds = derived(markedItems, $items => $items.map(item => item.name));
+  const markedItem = derived(store, $items => $items.find(item => item.isMarked))
 
   const configuredItems = derived(store, $items => $items.filter(item => item.meta.isConfigured || item.meta.isMandatory));
 
@@ -138,6 +142,7 @@ export function createObjectReferenceStore(
     removeTypeReference,
     markedItems,
     markedItemIds,
+    markedItem,
     configuredItems,
     isDirty,
     reset,

--- a/libs/oscd-template-generator/src/lib/stores/objectReferenceStore.ts
+++ b/libs/oscd-template-generator/src/lib/stores/objectReferenceStore.ts
@@ -71,15 +71,24 @@ export function createObjectReferenceStore(
     );
   }
 
+ /**
+ * Handles card selection when a card is clicked.
+ *
+ * If the clicked card is already selected, it will be deselected.
+ * If a different card is clicked, the selection switches to the new card,
+ * ensuring that only one card is selected at any time.
+ *
+ * @param {string} id - The id of the card that to toggle / select.
+ */
   function toggleMarked(id: string) {
     update(list =>
-      list.map(item => item.name === id ? { ...item, isMarked: !item.isMarked } : item)
+      list.map(item => item.name === id ? { ...item, isMarked: !item.isMarked } : {...item, isMarked: false})
     );
   }
 
   function setTypeReference(id: string, typeRef: string) {
     update(list =>
-      list.map(item => item.name === id ? { ...item, typeRef, meta: { ...item.meta, isConfigured: true }, } : item)
+      list.map(item => item.name === id ? { ...item, typeRef, isMarked: false, meta: { ...item.meta, isConfigured: true }, } : item)
     );
   }
 

--- a/libs/oscd-template-generator/src/lib/utils/overlayUitils.ts
+++ b/libs/oscd-template-generator/src/lib/utils/overlayUitils.ts
@@ -24,7 +24,7 @@ export function openDataObjectTypeDrawer(
 ) {
   openDrawer({
     component: DoTypeDrawer,
-    title: 'DO Details',
+    title: `DO: ${typeId}`,
     props: { mode, typeId, cdc },
   });
 }
@@ -145,7 +145,7 @@ export function openDataAttributeTypeDrawer(
 ) {
   openDrawer({
     component: DaTypeDrawer,
-    title: 'DA Details',
+    title: `DA: ${typeId}`,
     props: { mode, typeId, instanceType },
   });
 }
@@ -157,7 +157,7 @@ export function openDataEnumTypeDrawer(
 ) {
   openDrawer({
     component: EnumTypeDetailsDrawer,
-    title: 'Enum Details',
+    title: `Enum: ${typeId}`,
     props: { mode, typeId, instanceTypeId: instanceType },
   });
 }

--- a/libs/oscd-template-generator/src/lib/utils/overlayUitils.ts
+++ b/libs/oscd-template-generator/src/lib/utils/overlayUitils.ts
@@ -15,7 +15,9 @@ import { OscdConfirmDialog } from '@oscd-transnet-plugins/oscd-component';
 import ChooseInstanceTypeDialog from '../components/dialogs/ChooseInstanceTypeDialog.svelte';
 import { toastService } from '@oscd-transnet-plugins/oscd-services/toast';
 import { getDataTypeService } from '../services';
-import { TypeRenameDialog } from '../components';
+import { AddReferenceDialog, TypeRenameDialog } from '../components';
+import { get } from 'svelte/store';
+import type { ObjectReferenceStore } from '../stores';
 
 export function openDataObjectTypeDrawer(
   mode: Mode,
@@ -270,4 +272,99 @@ function dataTypeKindToText(kind: DataTypeKind): string {
       typeText = 'Type';
   }
   return typeText;
+}
+
+export async function openDataTypeDrawer(
+  typeKind: DataTypeKind,
+  mode: Mode,
+  typeId: string,
+  instanceType?: string
+) {
+  switch (typeKind) {
+    case DataTypeKind.DOType:
+      openDataObjectTypeDrawer(mode, typeId, instanceType);
+      return;
+    case DataTypeKind.DAType:
+      openDataAttributeTypeDrawer(mode, typeId, instanceType);
+      return;
+    case DataTypeKind.EnumType:
+      openDataEnumTypeDrawer(mode, typeId, instanceType);
+      return;
+    default:
+      console.error("open data type dialog drawer. type kind ", typeKind, " is not supported.")
+  }
+}
+
+export async function assignOrCreateReference(
+  refStore: ObjectReferenceStore,
+  srcTypeKind: DataTypeKind,
+  srcInstanceType: string,
+  targetRefId: string
+){
+
+  const ref = get(refStore).find(i => i.name === targetRefId);
+  const refTypeKind = ref.meta.refTypeKind
+  const instance = ref.meta.objectType
+  const res = await openDialog(AddReferenceDialog, {
+    typeKind: srcTypeKind,
+    instanceType: srcInstanceType,
+    objTypeKind: refTypeKind,
+    objInstanceType: instance,
+    itemId: targetRefId
+  });
+
+  if (res.type !== 'confirm') {
+    return;
+  }
+
+  const data = res.data;
+
+  refStore.setTypeReference(targetRefId, data.id)
+  if (data.mode === 'create') {
+    openDataTypeDrawer(refTypeKind, 'create', data.id, data.instanceType)
+  }
+}
+
+
+/**
+ * This utility function that manages the workflow of adding a new type directly for an object reference. 
+ * Based on the DataTypeKind and the required instanceType, it opens the create new data type dialog, with the 
+ * required instance type already selected. For references that can take any instance the instance type will not be preselected.
+ * Open sucessfull creation, the details view for the new type is created and the newly create type is reference to the given 
+ * object refence (item id).
+ * @param refStore  ObjectReference Store
+ * @param itemId  item id of the item in the ObjectReferenceStore, where you want to assign a new type.
+ */
+export async function createAndAddReference(refStore: ObjectReferenceStore, itemId: string): Promise<void> {
+  const ref = get(refStore).find(i => i.name === itemId);
+    const refTypeKind = ref.meta.refTypeKind
+    const instance = ref.meta.objectType
+
+    if (refTypeKind === DataTypeKind.DOType) {
+
+      const result = await openDialog(NewDataObjectTypeDialog, {defaultInstance: instance})
+      if (result.type !== 'confirm') return;
+
+      refStore.setTypeReference(ref.name, result.data.id)
+      openDataObjectTypeDrawer('create', result.data.id, result.data.cdc);
+
+    } else if (refTypeKind === DataTypeKind.DAType) {
+      
+      const result = await openDialog(NewDataAttributeTypeDialog, {defaultInstance: instance})
+      if (result.type !== 'confirm') return;
+
+      refStore.setTypeReference(ref.name, result.data.id)
+      openDataAttributeTypeDrawer('create', result.data.id, result.data.instanceType);
+
+    } else if (refTypeKind === DataTypeKind.EnumType) {
+      const result = await openDialog(NewEnumTypeDialog, {defaultInstance: instance})
+      if (result.type !== 'confirm') return;
+
+      refStore.setTypeReference(ref.name, result.data.id)
+      openDataEnumTypeDrawer('create', result.data.id, result.data.instanceType);
+
+    } else {
+      console.warn("Could not add and create refernce for refTypeKind: ", refTypeKind)
+      return;
+    }
 }

--- a/libs/oscd-template-generator/src/lib/utils/overlayUitils.ts
+++ b/libs/oscd-template-generator/src/lib/utils/overlayUitils.ts
@@ -24,7 +24,7 @@ export function openDataObjectTypeDrawer(
 ) {
   openDrawer({
     component: DoTypeDrawer,
-    title: `DO: ${typeId}`,
+    title: `[DO] ${typeId}`,
     props: { mode, typeId, cdc },
   });
 }
@@ -145,7 +145,7 @@ export function openDataAttributeTypeDrawer(
 ) {
   openDrawer({
     component: DaTypeDrawer,
-    title: `DA: ${typeId}`,
+    title: `[DA] ${typeId}`,
     props: { mode, typeId, instanceType },
   });
 }
@@ -157,7 +157,7 @@ export function openDataEnumTypeDrawer(
 ) {
   openDrawer({
     component: EnumTypeDetailsDrawer,
-    title: `Enum: ${typeId}`,
+    title: `[Enum] ${typeId}`,
     props: { mode, typeId, instanceTypeId: instanceType },
   });
 }

--- a/libs/theme/src/lib/global.css
+++ b/libs/theme/src/lib/global.css
@@ -13,7 +13,7 @@
   --mdc-theme-text-primary-on-background: var(--base01);
   --mdc-theme-text-secondary-on-background: var(--base00);
   --mdc-theme-text-icon-on-background: var(--base00);
-  --mdc-theme-error: var(--red);
+  --mdc-theme-error: #b71c1c;
 
   --mdc-button-disabled-ink-color: var(--base1);
 
@@ -65,6 +65,10 @@
 
 .mdc-drawer span.mdc-drawer__title {
   color: var(--mdc-theme-text-primary-on-background) !important;
+}
+
+.mdc-text-field--focused:not(.mdc-text-field--disabled) .mdc-floating-label {
+  color: var(--primary-base) !important;
 }
 
 abbr {

--- a/libs/theme/src/lib/global.css
+++ b/libs/theme/src/lib/global.css
@@ -47,6 +47,20 @@
 
   --oscd-text-font: var(--oscd-theme-text-font, 'Roboto');
   --oscd-icon-font: var(--oscd-theme-icon-font, 'Material Icons');
+
+    /* MDC Switch Overwrites */
+  --mdc-switch-selected-track-color: #6B9197;
+
+  --mdc-switch-selected-focus-track-color: #6B9197;
+  --mdc-switch-selected-hover-track-color: #6B9197;
+  --mdc-switch-selected-pressed-track-color: #6B9197;
+  --mdc-switch-selected-track-color: #6B9197;
+  --mdc-switch-unselected-icon-color: #fff;
+
+  --mdc-switch-selected-handle-color: var(--mdc-theme-primary, #676778);
+  --mdc-switch-selected-hover-handle-color: var(--mdc-theme-primary, #676778);
+  --mdc-switch-selected-pressed-handle-color: var(--mdc-theme-primary, #676778);
+  --mdc-switch-selected-focus-handle-color: var(--mdc-theme-primary, #676778);;
 }
 
 .mdc-drawer span.mdc-drawer__title {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@smui/dialog": "^8.0.0",
     "@smui/icon-button": "^8.0.0",
     "@smui/linear-progress": "^8.0.0",
+    "@smui/radio": "^8.0.0",
     "@smui/paper": "^8.0.0",
     "@smui/chips": "^8.0.0",
     "@smui/switch": "^8.0.0",


### PR DESCRIPTION
- ui color updates
- "add reference" btn: efficient type assignments: either create new or assign existing

Stories:
- OPENSCD-89: mark obj card by click on card
- OPENSCD-88: create modal change order of instance type select and type id
- OPENSCD-90: Add from object reference ("add reference")
- OPENSCD-91: Search field, also search by instance type
- OPENSCD-100: Add breadcrumbs to drawer
