### PR TITLE
Feature/template id format from db

### DIFF
--- a/apps/template-generator/src/bootstrap.ts
+++ b/apps/template-generator/src/bootstrap.ts
@@ -1,8 +1,10 @@
 import { createCustomResourceClient, createCustomResourceService } from "@oscd-transnet-plugins/api-compas-custom-resource";
 import { DefaultTypeService } from "./features/default-types/service/default-type.service";
+import { IdFormatSettingsService } from "./features/id-format-settings/id-format-settings.service";
 
 const COMPAS_SCL_DATA_SERVICE_BASE_URL = import.meta.env.VITE_COMPAS_SCL_DATA_SERVICE_BASE_URL || "/compas-scl-data-service";
 
 const customResourceApiClient = createCustomResourceClient(COMPAS_SCL_DATA_SERVICE_BASE_URL)
 const customResourceService = createCustomResourceService(customResourceApiClient);
 export const defaultTypeService = new DefaultTypeService(customResourceService);
+export const idFormatSettingsService = new IdFormatSettingsService(customResourceService);

--- a/apps/template-generator/src/features/id-format-settings/IdFormatSettings.svelte
+++ b/apps/template-generator/src/features/id-format-settings/IdFormatSettings.svelte
@@ -159,6 +159,12 @@
     state.load(true);
   });
 
+  $effect(() => {
+    if (state.error) {
+      toastService.error('ID Settings', state.error);
+    }
+  });
+
   function getSetting(kind: Kind) {
     return kind === 'global'
       ? state.settings.global

--- a/apps/template-generator/src/features/id-format-settings/id-format-settings.service.ts
+++ b/apps/template-generator/src/features/id-format-settings/id-format-settings.service.ts
@@ -1,0 +1,61 @@
+import { UploadDataContentTypeEnum, UploadDataNextVersionTypeEnum, type CustomResourceService, type PagedDataEntryResponse } from "@oscd-transnet-plugins/api-compas-custom-resource";
+import type { TypeIdFormatSettings } from "./types";
+
+export class IdFormatSettingsService {
+
+    static CUSTOM_RESOURCE_TYPE = "template-generator-id-format-settings";
+    static DATA_COMPATIBILITY_VERSION = "1.0.0";
+
+    constructor(private customResourceService: CustomResourceService) {}
+
+    /**
+     * Get ID format settings.
+     * @returns The ID format settings, or null if no settings exist or if there was an error parsing the settings. 
+     */
+    async getSettings(): Promise<TypeIdFormatSettings | null> {
+        // fetch list of settings (should only be one)
+        const settingsData: PagedDataEntryResponse = await this.customResourceService.listData({
+            type: IdFormatSettingsService.CUSTOM_RESOURCE_TYPE,
+            page: 0,
+            size: 1
+        });
+
+        // if no settings exist, return null
+        if (!settingsData?.content || settingsData.content.length === 0) {
+            return null;
+        }
+
+        // fetch details
+        const settingsId = settingsData.content[0].id;
+        const settingsDetails = await this.customResourceService.getById(settingsId);
+        if (!settingsDetails || !settingsDetails.content) {
+            return null;
+        }
+        
+        // parse content
+        try {
+            const settings: TypeIdFormatSettings = JSON.parse(settingsDetails.content);
+            return settings;
+        } catch (error) {
+            console.error('Failed to parse ID format settings content:', error);
+            return null;
+        }
+    }
+
+    /**
+     * Save ID format settings.
+     * @param settings The ID format settings to save.
+     */
+    async saveSettings(settings: TypeIdFormatSettings): Promise<void> {
+        const content = new Blob([JSON.stringify(settings)], { type: 'application/json' });
+
+        await this.customResourceService.upload({
+            type: IdFormatSettingsService.CUSTOM_RESOURCE_TYPE,
+            name: 'id-format-settings',
+            contentType: UploadDataContentTypeEnum.Json,
+            content,
+            dataCompatibilityVersion: IdFormatSettingsService.DATA_COMPATIBILITY_VERSION,
+            nextVersionType: UploadDataNextVersionTypeEnum.Patch
+        });
+    }
+}

--- a/apps/template-generator/src/features/id-format-settings/id-format-settings.state.svelte.ts
+++ b/apps/template-generator/src/features/id-format-settings/id-format-settings.state.svelte.ts
@@ -3,6 +3,7 @@ import { TypeKind } from "../../shared/model";
 import { getContext, setContext } from "svelte";
 import type { TypeIdFormatSetting, TypeIdFormatSettings } from "./types";
 import { idFormatSettingsService } from "../../bootstrap";
+import type { GenerateIdResult } from "../type-details/components/ui/CreateTypeForm.svelte";
 
 const TYPE_KINDS: TypeKind[] = [
     TypeKind.LNodeType,
@@ -101,6 +102,40 @@ class IdFormatSettingsState {
         return new OscdIdGenerator(format).generateId({ variables: ctx });
     }
 
+    /**
+     * Generate ID for a type and return result with user-facing error messages.
+     * Consolidates error handling for type ID generation across dialogs.
+     */
+    public generateIdWithResult(typeKind: TypeKind, ctx: { instance: string }): GenerateIdResult {
+        const generatedId = this.generateId(typeKind, ctx);
+        if (generatedId) {
+            return { id: generatedId };
+        }
+
+        if (this.error) {
+            return { message: 'ID format settings could not be loaded. Please try again.' };
+        }
+
+        return { message: 'No ID format is configured for this type. Configure it in ID Builder.' };
+    }
+
+    /**
+     * Generate reference ID for a type and return result with user-facing error messages.
+     * Consolidates error handling for reference ID generation across dialogs.
+     */
+    public generateReferenceIdWithResult(typeKind: TypeKind, ctx: { instance: string; reference: string }): GenerateIdResult {
+        const generatedId = this.generateReferenceId(typeKind, ctx);
+        if (generatedId) {
+            return { id: generatedId };
+        }
+
+        if (this.error) {
+            return { message: 'ID format settings could not be loaded. Please try again.' };
+        }
+
+        return { message: 'No ID format is configured for this type. Configure it in ID Builder.' };
+    }
+
     public setFormat(typeKind: TypeKind | 'global', idKind: 'format' | 'referenceFormat', format: IdFormat) {
         const setting = typeKind === 'global'
             ? this.settings.global
@@ -183,6 +218,6 @@ export function setIdSettingsState() {
     return setContext(ID_SETTINGS_STATE_KEY, new IdFormatSettingsState());
 }
 
-export function getIdSettingsState() {
-    return getContext<ReturnType<typeof setIdSettingsState>>(ID_SETTINGS_STATE_KEY);
+export function getIdSettingsState(): IdFormatSettingsState {
+    return getContext<IdFormatSettingsState>(ID_SETTINGS_STATE_KEY);
 }

--- a/apps/template-generator/src/features/id-format-settings/id-format-settings.state.svelte.ts
+++ b/apps/template-generator/src/features/id-format-settings/id-format-settings.state.svelte.ts
@@ -1,20 +1,8 @@
 import { OscdIdGenerator, type IdFormat } from "@oscd-transnet-plugins/oscd-services/id-generator";
 import { TypeKind } from "../../shared/model";
 import { getContext, setContext } from "svelte";
-
-interface TypeIdFormatSetting {
-    enabled: boolean;
-    format: IdFormat | null;
-    referenceFormatEnabled: boolean;
-    referenceFormat: IdFormat | null;
-}
-
-interface TypeIdFormatSettings {
-    global: TypeIdFormatSetting;
-    typeSpecific: {
-        [key in TypeKind]: TypeIdFormatSetting
-    }
-}
+import type { TypeIdFormatSetting, TypeIdFormatSettings } from "./types";
+import { idFormatSettingsService } from "../../bootstrap";
 
 const TYPE_KINDS: TypeKind[] = [
     TypeKind.LNodeType,
@@ -43,7 +31,7 @@ function createDefaultSettings(): TypeIdFormatSettings {
 
 class IdFormatSettingsState {
 
-    public settingsCacheTtlSeconds: number = 60;
+    public settingsCacheTtlSeconds: number = 45;
 
     loading: boolean = $state(false);
     error: string | null = $state(null);
@@ -72,10 +60,15 @@ class IdFormatSettingsState {
 
         // storage
         localStorage.setItem('idFormatSettings', JSON.stringify(saveToSettings));
-
-        this.settings = saveToSettings;
-        this.hasLoadedSettings = true;
-        this.settingsLoadedAt = Date.now();
+        try {
+            idFormatSettingsService.saveSettings(saveToSettings);
+            this.settings = saveToSettings;
+            this.hasLoadedSettings = true;
+            this.settingsLoadedAt = Date.now();
+        } catch (error) {
+            console.error('Failed to save ID format settings:', error);
+            this.error = 'Failed to save settings';
+        }
     }
 
     public generateId(typeKind: TypeKind, ctx: { instance: string }): string | undefined {
@@ -116,16 +109,16 @@ class IdFormatSettingsState {
     }
 
     private async fetchSettings(): Promise<TypeIdFormatSettings> {
-        const settingsString = localStorage.getItem('idFormatSettings');
-        if (settingsString) {
-            try {
-                const settings = JSON.parse(settingsString) as TypeIdFormatSettings;
-                return settings;
-            } catch (error) {
-                console.error('Failed to parse ID format settings from local storage:', error);
-                return createDefaultSettings();
+        try {
+            const fetchedSettings = await idFormatSettingsService.getSettings();
+            if (fetchedSettings) {
+                return fetchedSettings;
             }
+        } catch (error) {
+            this.error = 'Failed to fetch ID format settings';
+            console.error('Error fetching ID format settings:', error);
         }
+
         return createDefaultSettings();
     }
 

--- a/apps/template-generator/src/features/id-format-settings/types.d.ts
+++ b/apps/template-generator/src/features/id-format-settings/types.d.ts
@@ -1,0 +1,13 @@
+export interface TypeIdFormatSetting {
+    enabled: boolean;
+    format: IdFormat | null;
+    referenceFormatEnabled: boolean;
+    referenceFormat: IdFormat | null;
+}
+
+export interface TypeIdFormatSettings {
+    global: TypeIdFormatSetting;
+    typeSpecific: {
+        [key in TypeKind]: TypeIdFormatSetting
+    }
+}

--- a/apps/template-generator/src/features/type-details/components/DataTypesListView.svelte
+++ b/apps/template-generator/src/features/type-details/components/DataTypesListView.svelte
@@ -35,6 +35,7 @@
   let instance = $state<string | undefined>(undefined);
   let suspendedReloadDepth = 0;
   let hasPendingReload = false;
+  const idSettingsState = getIdSettingsState();
 
   const sortedDataTypes = $derived.by(() => {
     return sortSimpleDataTypes(dataTypes);
@@ -72,6 +73,7 @@
   async function openTypeDetails(type: SimpleDataType) {
     suspendedReloadDepth += 1;
     try {
+      await idSettingsState.load();
       await openTypeDetailsDrawer(type.id, type.typeKind, service, docState, 'edit');
     } finally {
       suspendedReloadDepth = Math.max(0, suspendedReloadDepth - 1);
@@ -83,6 +85,7 @@
   }
 
   async function createLNodeType() {
+    await idSettingsState.load();
     const createResult = await createDataTypeWorkflow(TypeKind.LNodeType, service, docState);
     if (!createResult) {
       return;
@@ -117,7 +120,7 @@
 
 
   onMount(() => {
-    getIdSettingsState().load();
+    idSettingsState.load();
     loadDataTypes();
   });
 </script>

--- a/apps/template-generator/src/features/type-details/components/dialogs/AddReferenceDialog.svelte
+++ b/apps/template-generator/src/features/type-details/components/dialogs/AddReferenceDialog.svelte
@@ -127,20 +127,10 @@
       return { message: 'Unable to auto-generate an ID for this reference type.' };
     }
 
-    const generatedId = idSettingsState.generateReferenceId(refTypeKind, {
+    return idSettingsState.generateReferenceIdWithResult(refTypeKind, {
       instance,
       reference: memberName,
     });
-
-    if (generatedId) {
-      return { id: generatedId };
-    }
-
-    if (idSettingsState.error) {
-      return { message: 'ID format settings could not be loaded. Please try again.' };
-    }
-
-    return { message: 'No ID format is configured for this type. Configure it in ID Builder.' };
   }
 </script>
 

--- a/apps/template-generator/src/features/type-details/components/dialogs/AddReferenceDialog.svelte
+++ b/apps/template-generator/src/features/type-details/components/dialogs/AddReferenceDialog.svelte
@@ -4,7 +4,10 @@
   import Radio from '@smui/radio';
   import FormField from '@smui/form-field';
   import { closeDialog } from '@oscd-transnet-plugins/oscd-services/dialog';
-  import CreateTypeForm, { type CreateTypeFormSubmitDetails } from '../ui/CreateTypeForm.svelte';
+  import CreateTypeForm, {
+    type CreateTypeFormSubmitDetails,
+    type GenerateIdResult,
+  } from '../ui/CreateTypeForm.svelte';
   import { DataTypeService } from '../../services/type.service';
   import type { SimpleDataType, TypeKind } from '../../../../shared/model';
   import { getIdSettingsState } from '../../../id-format-settings/id-format-settings.state.svelte.js';
@@ -118,6 +121,27 @@
       mode,
     });
   }
+
+  function generateReferenceTypeId(instance: string): GenerateIdResult {
+    if (!refTypeKind) {
+      return { message: 'Unable to auto-generate an ID for this reference type.' };
+    }
+
+    const generatedId = idSettingsState.generateReferenceId(refTypeKind, {
+      instance,
+      reference: memberName,
+    });
+
+    if (generatedId) {
+      return { id: generatedId };
+    }
+
+    if (idSettingsState.error) {
+      return { message: 'ID format settings could not be loaded. Please try again.' };
+    }
+
+    return { message: 'No ID format is configured for this type. Configure it in ID Builder.' };
+  }
 </script>
 
 <OscdBaseDialog
@@ -194,11 +218,7 @@
             canChooseInstaceType={false}
             onChange={handleFormChange}
             onSubmit={handleFormSubmit}
-            generateId={(instance) =>
-              idSettingsState.generateReferenceId(refTypeKind, {
-                instance,
-                reference: memberName,
-              })}
+            generateId={generateReferenceTypeId}
             {service}
           />
         {/if}

--- a/apps/template-generator/src/features/type-details/components/dialogs/CreateTypeDialog.svelte
+++ b/apps/template-generator/src/features/type-details/components/dialogs/CreateTypeDialog.svelte
@@ -7,6 +7,7 @@
   import { closeDialog } from '@oscd-transnet-plugins/oscd-services/dialog';
   import { getIdSettingsState } from '../../../id-format-settings/id-format-settings.state.svelte.js';
   import type { DataTypeService } from '../../services/type.service';
+  import type { GenerateIdResult } from '../ui/CreateTypeForm.svelte';
 
   const idSettingsState = getIdSettingsState();
 
@@ -46,6 +47,19 @@
   function handleClose() {
     closeDialog('exit');
   }
+
+  function generateTypeId(instance: string): GenerateIdResult {
+    const generatedId = idSettingsState.generateId(typeKind, { instance });
+    if (generatedId) {
+      return { id: generatedId };
+    }
+
+    if (idSettingsState.error) {
+      return { message: 'ID format settings could not be loaded. Please try again.' };
+    }
+
+    return { message: 'No ID format is configured for this type. Configure it in ID Builder.' };
+  }
 </script>
 
 <OscdBaseDialog
@@ -65,8 +79,7 @@
         showCreateFromDefaultOption={typeKind === TypeKind.LNodeType}
         onChange={handleFormChange}
         onSubmit={handleFormSubmit}
-        generateId={(instance) =>
-          idSettingsState.generateId(typeKind, { instance })}
+        generateId={generateTypeId}
         {service}
       />
     </div>

--- a/apps/template-generator/src/features/type-details/components/dialogs/CreateTypeDialog.svelte
+++ b/apps/template-generator/src/features/type-details/components/dialogs/CreateTypeDialog.svelte
@@ -49,16 +49,7 @@
   }
 
   function generateTypeId(instance: string): GenerateIdResult {
-    const generatedId = idSettingsState.generateId(typeKind, { instance });
-    if (generatedId) {
-      return { id: generatedId };
-    }
-
-    if (idSettingsState.error) {
-      return { message: 'ID format settings could not be loaded. Please try again.' };
-    }
-
-    return { message: 'No ID format is configured for this type. Configure it in ID Builder.' };
+    return idSettingsState.generateIdWithResult(typeKind, { instance });
   }
 </script>
 

--- a/apps/template-generator/src/features/type-details/components/ui/CreateTypeForm.svelte
+++ b/apps/template-generator/src/features/type-details/components/ui/CreateTypeForm.svelte
@@ -14,6 +14,11 @@
     valid: boolean;
   }
 
+  export interface GenerateIdResult {
+    id?: string;
+    message?: string;
+  }
+
   interface Props {
     typeKind: TypeKind;
 
@@ -24,7 +29,7 @@
     createFromDefault?: boolean;
     onChange?: (event: CreateTypeFormSubmitDetails) => void;
     onSubmit?: (event: CreateTypeFormSubmitDetails) => void;
-    generateId?: (instance: string) => string;
+    generateId?: (instance: string) => string | GenerateIdResult | undefined;
 
     service: DataTypeService;
   }
@@ -50,6 +55,7 @@
 
   let isTypeIdValid = $state<boolean>(false);
   let isFormValid = $derived<boolean>(!!selectedInstance && isTypeIdValid);
+  let generateFeedback = $state<string>('');
 
   let loading = $state<boolean>(false);
 
@@ -97,9 +103,24 @@
     autoGenerateId(selectedInstance?.instance);
   });
 
-  function autoGenerateId(instance: string | undefined) {
-    if (generateId && instance) {
-      typeId = generateId(instance);
+  function autoGenerateId(instance: string | undefined, fromUserClick = false) {
+    generateFeedback = '';
+    if (!generateId || !instance) {
+      return;
+    }
+
+    const generationResult = generateId(instance);
+    const normalizedResult = typeof generationResult === 'string'
+      ? { id: generationResult }
+      : (generationResult ?? {});
+
+    if (normalizedResult.id) {
+      typeId = normalizedResult.id;
+      return;
+    }
+
+    if (fromUserClick) {
+      generateFeedback = normalizedResult.message ?? 'Unable to auto-generate an ID.';
     }
   }
 
@@ -126,10 +147,17 @@
       bind:this={idInputEl}
       bind:typeId
       bind:valid={isTypeIdValid}
+      {generateFeedback}
+      onIdInput={() => {
+        generateFeedback = '';
+      }}
+      onIdBlur={() => {
+        generateFeedback = '';
+      }}
       showErrorsOnInput
       disabled={!selectedInstance}
       generateId={generateId
-        ? () => autoGenerateId(selectedInstance?.instance)
+        ? () => autoGenerateId(selectedInstance?.instance, true)
         : undefined}
       {service}
     />

--- a/apps/template-generator/src/features/type-details/components/ui/CreateTypeForm.svelte
+++ b/apps/template-generator/src/features/type-details/components/ui/CreateTypeForm.svelte
@@ -29,7 +29,7 @@
     createFromDefault?: boolean;
     onChange?: (event: CreateTypeFormSubmitDetails) => void;
     onSubmit?: (event: CreateTypeFormSubmitDetails) => void;
-    generateId?: (instance: string) => string | GenerateIdResult | undefined;
+    generateId?: (instance: string) => GenerateIdResult;
 
     service: DataTypeService;
   }
@@ -44,7 +44,7 @@
     createFromDefault = $bindable(false),
     onChange = (_event: CreateTypeFormSubmitDetails) => {},
     onSubmit = (_event: CreateTypeFormSubmitDetails) => {},
-    generateId = (_instance: string) => '',
+    generateId = (_instance: string) => ({ }),
     service,
   }: Props = $props();
 
@@ -110,17 +110,14 @@
     }
 
     const generationResult = generateId(instance);
-    const normalizedResult = typeof generationResult === 'string'
-      ? { id: generationResult }
-      : (generationResult ?? {});
 
-    if (normalizedResult.id) {
-      typeId = normalizedResult.id;
+    if (generationResult.id) {
+      typeId = generationResult.id;
       return;
     }
 
     if (fromUserClick) {
-      generateFeedback = normalizedResult.message ?? 'Unable to auto-generate an ID.';
+      generateFeedback = generationResult.message ?? 'Unable to auto-generate an ID.';
     }
   }
 

--- a/apps/template-generator/src/features/type-details/components/ui/TypeIdInput.svelte
+++ b/apps/template-generator/src/features/type-details/components/ui/TypeIdInput.svelte
@@ -14,8 +14,12 @@
     idLabel?: string;
     showErrorsOnInput?: boolean;
     generateId?: () => void;
+    generateFeedback?: string;
+    onIdInput?: () => void;
+    onIdBlur?: () => void;
     disabled?: boolean;
     service: DataTypeService;
+    required?: boolean;
   }
 
   let {
@@ -24,8 +28,12 @@
     idLabel = 'Enter Type ID',
     showErrorsOnInput = false,
     generateId,
+    generateFeedback = '',
+    onIdInput = () => {},
+    onIdBlur = () => {},
     disabled = false,
-    service
+    service,
+    required = false
   }: Props = $props();
 
   let inputEl;
@@ -41,6 +49,7 @@
   let isTypeIdValid = $derived<boolean>(
     isTypeIdRequiredValid && isTypeIdFormatValid && isTypeIdAvailable,
   );
+  let showValidationMessage = $derived<boolean>(showErrorsOnInput || typeIdTouched);
 
   function typeIdExists(candidateId: string): boolean {
     return service.exists(candidateId);
@@ -75,6 +84,15 @@
   export function select() {
     getInput().select();
   }
+  function handleBlur() {
+    typeIdTouched = true;
+    onIdBlur();
+  }
+
+  function handleInput() {
+    onIdInput();
+  }
+
 </script>
 
 <TextField
@@ -84,8 +102,10 @@
   style="width: 100%;"
   input$maxlength={ID_MAX_LENGTH}
   {disabled}
-  onblur={() => (typeIdTouched = true)}
+  onblur={handleBlur}
+  oninput={handleInput}
   invalid={!isTypeIdValid}
+  required={required}
 >
   {#snippet trailingIcon()}
     {#if generateId}
@@ -98,7 +118,7 @@
             generateId();
           }}
           style="all: unset; cursor: pointer;"
-          disabled={!generateId}
+          disabled={!generateId || disabled}
         >
           <Icon class="material-icons">autorenew</Icon>
         </button>
@@ -108,11 +128,13 @@
 
   {#snippet helper()}
     <HelperText validationMsg persistent>
-      {#if (showErrorsOnInput || typeIdTouched) && !isTypeIdRequiredValid}
+      {#if generateFeedback}
+        {generateFeedback}
+      {:else if showValidationMessage && !isTypeIdRequiredValid}
         Please enter an ID.
-      {:else if (showErrorsOnInput || typeIdTouched) && !isTypeIdFormatValid}
+      {:else if showValidationMessage && !isTypeIdFormatValid}
         ID must contain no spaces.
-      {:else if (showErrorsOnInput || typeIdTouched) && !isTypeIdAvailable}
+      {:else if showValidationMessage && !isTypeIdAvailable}
         That ID is already in use. Please choose a different one.
       {/if}
     </HelperText>


### PR DESCRIPTION
- Integrate ID Format Setting with non-sCL resource endpoint
- Add feedback message for TypeIdInput when click on generate id and
  - an error occured
  - no id format is configured
