### PR TITLE
feat(template): add apply default preview toggle use default (#OPENSCD-310)

### DIFF
--- a/apps/template-generator/src/features/type-details/components/TypeDetails.svelte
+++ b/apps/template-generator/src/features/type-details/components/TypeDetails.svelte
@@ -6,7 +6,7 @@
   import { createDataTypeWorkflow } from '../type.workflows';
   import { openTypeDetailsDrawer } from '../type-details.drawer';
   import AddReferenceDialog from './dialogs/AddReferenceDialog.svelte';
-  import { DataTypeService } from '../services/type.service';
+  import { DataTypeService, type ApplyDefaultTypesPreview } from '../services/type.service';
   import TypeDetailsLayout from './TypeDetailsLayout.svelte';
   import TBoardTypeDetailsView from './TBoardTypeDetailsView.svelte';
   import EnumTypeDetails from './EnumTypeDetails.svelte';
@@ -195,15 +195,45 @@
     };
   });
 
-  async function applyDefaults(members: string[]  | undefined = undefined) {
+  /**
+   * Filters the apply default preview to only include entries for the selected member names.
+   * @param preview The apply default types preview to filter.
+   * @param selectedNames The set of selected member names to include in the filtered preview.
+   * @returns A new apply default types preview containing only the entries for the selected member names.
+   */
+  function filterPreviewByMembers(
+    preview: ApplyDefaultTypesPreview,
+    selectedNames: Set<string>,
+  ): ApplyDefaultTypesPreview {
+    const filteredEntries = preview.entries
+      .map((entry) => ({ ...entry, memberNames: entry.memberNames.filter((n) => selectedNames.has(n)) }))
+      .filter((entry) => entry.memberNames.length > 0);
+    return { ...preview, entries: filteredEntries };
+  }
+
+  async function applyDefaults(members: string[] | undefined = undefined) {
     try {
+      // For single-member applies: pre-select that member
+      // For apply-all: pre-select only configured/mandatory members
+      const configuredMemberNames = members && members.length > 0
+        ? members
+        : typeDetailsState.getConfiguredMemberNames();
+      const memberReferenceMap = typeDetailsState.getMemberReferenceMap();
       const preview = await typeDetailsState.getApplyDefaultTypesPreview(members);
+      if (preview === null) {
+        toastService.info('No defaults to apply', 'There are no default types to apply for the members of this type.');
+        return;
+      }
       const result = await openDialog(ApplyDefaultPreviewConfirmDialog, {
         applyDefaultPreview: preview,
+        configuredMemberNames,
+        memberReferenceMap,
       });
-    if(result.type === 'confirm') {
-      typeDetailsState.applyDefaultTypesFromPreview(preview);
-    }
+      if (result.type === 'confirm') {
+        const selectedNames = new Set<string>((result.data?.selectedMemberNames as string[]) ?? []);
+        const filteredPreview = filterPreviewByMembers(preview, selectedNames);
+        typeDetailsState.applyDefaultTypesFromPreview(filteredPreview);
+      }
     } catch (e) {
       console.error('Failed to get apply default types preview', e);
       toastService.error('Apply default failed', 'Failed to get apply default types. Please try again.');

--- a/apps/template-generator/src/features/type-details/components/dialogs/ApplyDefaultMemberRow.svelte
+++ b/apps/template-generator/src/features/type-details/components/dialogs/ApplyDefaultMemberRow.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+  import { OscdSwitch, OscdBox } from '@oscd-transnet-plugins/oscd-component';
+  import Card from '@smui/card';
+  import type { ApplyScenario } from '../../services/default-type-manager-service';
+
+  interface Props {
+    memberName: string;
+    refTypeLabel: string;
+    referenceId: string | null;
+    versionTo: string | null;
+    refTypeKey?: string;
+    scenario?: ApplyScenario;
+    willApply: boolean;
+    isSelected: boolean;
+    existingReference: string | null;
+    onToggle: () => void;
+  }
+
+  const {
+    memberName,
+    refTypeLabel,
+    referenceId,
+    versionTo,
+    willApply,
+    isSelected,
+    existingReference,
+    onToggle,
+  }: Props = $props();
+</script>
+
+<Card
+  padded
+  variant="outlined"
+  class={`row-card ${!willApply ? 'unavailable' : ''}`}
+>
+  <header class="row-header">
+    <div class="row-title" class:muted-text={!willApply}>
+      {memberName}
+    </div>
+    <OscdSwitch
+      checked={willApply ? isSelected : false}
+      disabled={!willApply}
+      onChange={onToggle}
+      id={`member-toggle-${memberName}`}
+      label="Use default"
+      align="end"
+      labelStyle={`font-size: 0.8rem; ${
+        willApply ? 'color: var(--mdc-theme-primary);' : ''
+      }`}
+    />
+  </header>
+  <div class="row-grid">
+    {#if willApply}
+      <div>
+        <div class="field-label">Reference ID</div>
+        <div class="field-value mono">{referenceId}</div>
+      </div>
+      <div>
+        <div class="field-label">Reference Type</div>
+        <div class="field-value">{refTypeLabel}</div>
+      </div>
+      <div>
+        <div class="field-label">
+          Version <span class="version-note">(latest)</span>
+        </div>
+        <div class="field-value">{versionTo ?? '-'}</div>
+      </div>
+    {:else}
+      <div>
+        <div class="field-label">Reference Type</div>
+        <div class="field-value muted-text">{refTypeLabel}</div>
+      </div>
+      <div>
+        <div class="field-label">Reason</div>
+        <div class="field-value muted-text">
+          No default exists for this reference type.
+        </div>
+      </div>
+    {/if}
+  </div>
+  {#if willApply && existingReference && isSelected}
+    <div class="overwrite-box">
+      <OscdBox
+        type="warning"
+        size="compact"
+        message="Overwrites current reference: {existingReference}"
+      />
+    </div>
+  {/if}
+</Card>
+
+<style>
+  :global(.row-card.unavailable) {
+    opacity: 0.7;
+  }
+
+  .row-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 0.5rem;
+  }
+
+  .row-title {
+    font-weight: var(--tg-font-weight-heading);
+    color: #202b36;
+
+    &.muted-text {
+      color: #718096;
+    }
+  }
+
+  .row-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.5rem;
+  }
+
+  .field-label {
+    font-size: var(--tg-font-size-small);
+    color: #697786;
+  }
+
+  .field-value {
+    margin-top: 0.15rem;
+    color: #1f2933;
+    font-size: var(--tg-font-size-body);
+    word-break: break-word;
+
+    &.muted-text {
+      color: #718096;
+    }
+  }
+
+  .version-note {
+    font-size: 0.65rem;
+    color: #a0aec0;
+    font-weight: var(--tg-font-weight-normal);
+    letter-spacing: 0.02em;
+  }
+
+  .mono {
+    font-family:
+      var(--tg-font-family), ui-monospace, SFMono-Regular, Menlo, Monaco,
+      Consolas, 'Liberation Mono', 'Courier New', monospace;
+  }
+
+  .overwrite-box {
+    margin-top: 0.35rem;
+  }
+</style>

--- a/apps/template-generator/src/features/type-details/components/dialogs/ApplyDefaultPreviewConfirmDialog.svelte
+++ b/apps/template-generator/src/features/type-details/components/dialogs/ApplyDefaultPreviewConfirmDialog.svelte
@@ -1,26 +1,26 @@
 <script lang="ts">
   import { closeDialog } from "@oscd-transnet-plugins/oscd-services/dialog";
-  import { OscdBaseDialog } from '@oscd-transnet-plugins/oscd-component';
+  import { OscdBaseDialog, OscdSwitch } from '@oscd-transnet-plugins/oscd-component';
   import Card from '@smui/card';
   import type { ApplyScenario } from '../../services/default-type-manager-service';
   import type { ApplyDefaultTypesPreview, ApplyDefaultTypesPreviewEntry } from "../../services/type.service";
+  import ApplyDefaultMemberRow from './ApplyDefaultMemberRow.svelte';
 
   interface Props {
     open?: boolean;
-    applyDefaultPreview: ApplyDefaultTypesPreview
+    applyDefaultPreview: ApplyDefaultTypesPreview;
+    configuredMemberNames?: string[];
+    memberReferenceMap?: Record<string, string | undefined>;
   }
 
   let {
     open = $bindable(false),
     applyDefaultPreview,
+    configuredMemberNames = [],
+    memberReferenceMap = {},
   }: Props = $props();
 
-  const scenarioMeta: Record<ApplyScenario, { label: string; tone: 'success' | 'danger' }> = {
-    ADD_DB_DEFAULT: { label: 'To apply', tone: 'success' },
-    USE_LOCAL_DEFAULT: { label: 'To apply', tone: 'success' },
-    UPGRADE_TO_DB_DEFAULT: { label: 'To apply', tone: 'success' },
-    REMOVE_LOCAL_DEFAULT: { label: 'No default', tone: 'danger' },
-  };
+  let selectedMemberNames = $state(new Set<string>());
 
   type MemberPreviewRow = {
     memberName: string;
@@ -32,6 +32,7 @@
     versionFrom: string | null;
     versionTo: string | null;
     isUpgrade: boolean;
+    existingReference: string | null;
   };
 
   const entries = $derived(applyDefaultPreview?.entries ?? []);
@@ -59,6 +60,7 @@
             versionFrom,
             versionTo,
             isUpgrade,
+            existingReference: memberReferenceMap[memberName] ?? null,
           } satisfies MemberPreviewRow;
         }),
       )
@@ -69,16 +71,69 @@
   const applicableRows = $derived(memberRows.filter((row) => row.willApply));
   const unavailableRows = $derived(memberRows.filter((row) => !row.willApply));
   const totalMembers = $derived(memberRows.length);
+
+  const configuredSet = $derived(new Set(configuredMemberNames));
+
+  $effect(() => {
+    const initial = new Set<string>();
+    for (const row of applicableRows) {
+      if (configuredSet.has(row.memberName)) {
+        initial.add(row.memberName);
+      }
+    }
+    selectedMemberNames = initial;
+  });
+
+  const selectedCount = $derived(selectedMemberNames.size);
+  const confirmText = $derived(
+    applicableRows.length === 0
+      ? 'Close'
+      : selectedCount === 0
+        ? 'Apply'
+        : `Apply (${selectedCount})`
+  );
+  const confirmDisabled = $derived(applicableRows.length > 0 && selectedCount === 0);
+
+  const allApplicableSelected = $derived(
+    applicableRows.length > 0 && selectedCount === applicableRows.length
+  );
+
+  function toggleMember(memberName: string) {
+    const next = new Set(selectedMemberNames);
+    if (next.has(memberName)) {
+      next.delete(memberName);
+    } else {
+      next.add(memberName);
+    }
+    selectedMemberNames = next;
+  }
+
+  function toggleAllApplicable() {
+    const next = new Set(selectedMemberNames);
+    if (allApplicableSelected) {
+      // Deselect all applicable rows
+      for (const row of applicableRows) {
+        next.delete(row.memberName);
+      }
+    } else {
+      // Select all applicable rows
+      for (const row of applicableRows) {
+        next.add(row.memberName);
+      }
+    }
+    selectedMemberNames = next;
+  }
 </script>
 
 <OscdBaseDialog
   title="Apply Default Preview"
-  confirmActionText={applicableRows.length === 0 ? 'Close' : 'Apply'}
+  confirmActionText={confirmText}
+  confirmDisabled={confirmDisabled}
   maxWidth="1000px"
   height="auto"
   maxHeight="80vh"
   bind:open
-  onConfirm={() => {closeDialog('confirm')}}
+  onConfirm={() => { closeDialog('confirm', { selectedMemberNames: [...selectedMemberNames] }) }}
   onCancel={() => closeDialog('cancel')}
   onClose={() => closeDialog('exit')}
 >
@@ -91,8 +146,8 @@
         </Card>
         {#if totalMembers > 1}
           <Card padded variant="outlined" class="summary-card">
-            <div class="summary-label">Will Be Assigned</div>
-            <div class="summary-value success-text">{applicableRows.length}</div>
+          <div class="summary-label">Will Be Applied</div>
+          <div class="summary-value success-text">{selectedCount}</div>
           </Card>
           <Card padded variant="outlined" class="summary-card">
             <div class="summary-label">No Default Available</div>
@@ -109,34 +164,36 @@
         <Card padded variant="outlined" class="empty-state">No applicable default updates found for the selected members.</Card>
       {:else}
         <section>
-          <div class="section-title">Will Be Applied</div>
+          <div class="section-header">
+            <div class="section-title">Will Be Applied</div>
+            {#if applicableRows.length > 1}
+              <OscdSwitch
+                checked={allApplicableSelected}
+                onChange={toggleAllApplicable}
+                id="bulk-toggle-applicable"
+                label="All"
+                align="end"
+                labelStyle="font-size: 0.8rem; color: var(--mdc-theme-primary);"
+              />
+            {/if}
+          </div>
           {#if applicableRows.length === 0}
             <Card padded variant="outlined" class="empty-state">No data objects.</Card>
           {:else}
             <div class="rows-list">
               {#each applicableRows as row}
-                <Card padded variant="outlined" class="row-card">
-                  <header class="row-header">
-                    <div class="row-title">{row.memberName}</div>
-                    <span class={`chip chip-${scenarioMeta[row.scenario].tone}`}>
-                      {scenarioMeta[row.scenario].label}
-                    </span>
-                  </header>
-                  <div class="row-grid">
-                      <div>
-                        <div class="field-label">Reference ID</div>
-                        <div class="field-value mono">{row.referenceId}</div>
-                      </div>
-                      <div>
-                        <div class="field-label">Reference Type</div>
-                        <div class="field-value">{row.refTypeLabel}</div>
-                      </div>
-                      <div>
-                        <div class="field-label">Version <span class="version-note">(latest)</span></div>
-                        <div class="field-value">{row.versionTo ?? '-'}</div>
-                      </div>
-                    </div>
-                </Card>
+                <ApplyDefaultMemberRow
+                  memberName={row.memberName}
+                  refTypeLabel={row.refTypeLabel}
+                  referenceId={row.referenceId}
+                  versionTo={row.versionTo}
+                  refTypeKey={row.refTypeKey}
+                  scenario={row.scenario}
+                  willApply={row.willApply}
+                  isSelected={selectedMemberNames.has(row.memberName)}
+                  existingReference={row.existingReference}
+                  onToggle={() => toggleMember(row.memberName)}
+                />
               {/each}
             </div>
           {/if}
@@ -147,22 +204,18 @@
             <div class="section-title muted-title">No Default Available</div>
             <div class="rows-list">
               {#each unavailableRows as row}
-                <Card padded variant="outlined" class="row-card unavailable">
-                  <header class="row-header">
-                    <div class="row-title muted-text">{row.memberName}</div>
-                    <span class="chip chip-danger">No default</span>
-                  </header>
-                  <div class="row-grid">
-                      <div>
-                        <div class="field-label">Reference Type</div>
-                        <div class="field-value muted-text">{row.refTypeLabel}</div>
-                      </div>
-                      <div>
-                        <div class="field-label">Reason</div>
-                        <div class="field-value muted-text">No default exists for this reference type.</div>
-                      </div>
-                    </div>
-                </Card>
+                <ApplyDefaultMemberRow
+                  memberName={row.memberName}
+                  refTypeLabel={row.refTypeLabel}
+                  referenceId={row.referenceId}
+                  versionTo={row.versionTo}
+                  refTypeKey={row.refTypeKey}
+                  scenario={row.scenario}
+                  willApply={row.willApply}
+                  isSelected={selectedMemberNames.has(row.memberName)}
+                  existingReference={row.existingReference}
+                  onToggle={() => toggleMember(row.memberName)}
+                />
               {/each}
             </div>
           </section>
@@ -186,125 +239,42 @@
     gap: 0.5rem;
   }
 
-  .summary-card {
-    height: 100%;
-  }
-
   .summary-label {
-    font-size: 0.75rem;
+    font-size: var(--tg-font-size-small);
     color: #5b6470;
   }
 
   .summary-value {
     margin-top: 0.25rem;
     font-size: 0.95rem;
-    font-weight: 600;
+    font-weight: var(--tg-font-weight-heading);
     color: #1f2933;
     word-break: break-word;
   }
 
-  .chip {
-    display: inline-flex;
-    align-items: center;
-    border-radius: 999px;
-    font-size: 0.75rem;
-    padding: 0.2rem 0.55rem;
-    border: 1px solid transparent;
-    font-weight: 600;
-  }
-
-  .chip-neutral {
-    background: #eef1f5;
-    border-color: #d0d7e1;
-    color: #445266;
-  }
-
-  .chip-success {
-    background: #e8f7ee;
-    border-color: #bde8cd;
-    color: #276749;
-  }
-
-  .chip-warning {
-    background: #fff4e5;
-    border-color: #ffd9a8;
-    color: #9c5a11;
-  }
-
-  .chip-danger {
-    background: #fdecec;
-    border-color: #f8c8c8;
-    color: #a63131;
-  }
-
-  .chip-muted {
-    background: #eef1f4;
-    border-color: #d6dde5;
-    color: #708090;
-  }
-
   .section-title {
-    font-size: 0.8rem;
+    font-size: var(--tg-font-size-small);
     color: #3b4a5a;
     margin: 0.25rem 0 0.35rem;
-    font-weight: 700;
+    font-weight: var(--tg-font-weight-heading);
+  }
+
+  .section-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+    margin-bottom: 0.35rem;
+  }
+
+  .section-header .section-title {
+    margin: 0;
   }
 
   .rows-list {
     display: flex;
     flex-direction: column;
     gap: 0.6rem;
-  }
-
-  .row-card {
-    display: flex;
-    flex-direction: column;
-    gap: 0.55rem;
-  }
-
-  .row-card.unavailable {
-    background: #f6f8fa;
-  }
-
-  .row-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-    gap: 0.5rem;
-  }
-
-  .row-title {
-    font-weight: 700;
-    color: #202b36;
-  }
-
-  .row-grid {
-    display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 0.5rem;
-  }
-
-  .field-label {
-    font-size: 0.72rem;
-    color: #697786;
-  }
-
-  .field-value {
-    margin-top: 0.15rem;
-    color: #1f2933;
-    font-size: 0.9rem;
-    word-break: break-word;
-  }
-
-  .version-note {
-    font-size: 0.65rem;
-    color: #a0aec0;
-    font-weight: 400;
-    letter-spacing: 0.02em;
-  }
-
-  .mono {
-    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
   }
 
   .success-text {
@@ -319,14 +289,8 @@
     color: #718096;
   }
 
-  .empty-state {
-    color: #5f6b7a;
-    background: #f9fbfd;
-  }
-
   @media (max-width: 760px) {
-    .summary-grid,
-    .row-grid {
+    .summary-grid {
       grid-template-columns: 1fr;
     }
   }

--- a/apps/template-generator/src/features/type-details/state/type.state.svelte.ts
+++ b/apps/template-generator/src/features/type-details/state/type.state.svelte.ts
@@ -294,6 +294,25 @@ export class DataTypeDetailsState {
         this.config = config;
     }
 
+    /**
+     * Get names of members that are either configured or mandatory.
+     */
+    public getConfiguredMemberNames(): string[] {
+        return this.loadedType?.members
+            .filter((m) => m.isConfigured || m.isMandatory)
+            .map((m) => m.name) ?? [];
+    }
+
+    /**
+     * Get a map of member names to their current reference IDs.
+     */
+    public getMemberReferenceMap(): Record<string, string | undefined> {
+        const map: Record<string, string | undefined> = {};
+        for (const m of this.loadedType?.members ?? []) {
+            map[m.name] = m.reference;
+        }
+        return map;
+    }
 
     private refreshData() {
         if (!this.loadedType) return;

--- a/libs/oscd-component/src/oscd-switch/OscdSwitch.svelte
+++ b/libs/oscd-component/src/oscd-switch/OscdSwitch.svelte
@@ -12,6 +12,8 @@
     icons?: boolean;
     preventToggleOnClick?: boolean;
     disabled?: boolean;
+    /** Label alignment */
+    align?: 'start' | 'end';
 
     onChange?: (newChecked: boolean) => void;
   }
@@ -26,6 +28,7 @@
     icons = false,
     preventToggleOnClick = false,
     disabled = false,
+    align = 'start',
 
     onChange = (_) => {},
   }: Props = $props();
@@ -43,7 +46,7 @@
   }
 </script>
 
-<FormField class={formFieldClass}>
+<FormField {align} class={formFieldClass}>
   <Switch
     id={id}
     disabled={disabled}

--- a/libs/oscd-component/src/oscd-warning-box/OscdBox.svelte
+++ b/libs/oscd-component/src/oscd-warning-box/OscdBox.svelte
@@ -81,11 +81,11 @@
   }
 
   .box-container.compact :global(.icon) {
-    font-size: 1rem;
+    font-size: var(--tg-font-size-subheading);
   }
 
   .box-container.compact .content {
-    font-size: 0.85rem;
+    font-size: var(--tg-font-size-body);
   }
 
   .box-container.compact .box-content {

--- a/libs/oscd-component/src/oscd-warning-box/OscdBox.svelte
+++ b/libs/oscd-component/src/oscd-warning-box/OscdBox.svelte
@@ -5,9 +5,10 @@
     children?: import('svelte').Snippet;
     message?: string;
     type?: 'success' | 'error' | 'info' | 'warning';
+    size?: 'default' | 'compact';
   }
 
-  let { children, message, type = 'warning' }: Props = $props();
+  let { children, message, type = 'warning', size = 'default' }: Props = $props();
 
   const icons = {
     success: 'check_circle',
@@ -24,7 +25,7 @@
   } as const;
 </script>
 
-<div class="box-container" style="--color: {colors[type]}">
+<div class="box-container" class:compact={size === 'compact'} style="--color: {colors[type]}">
   <div class="box-content">
     <div class="icon">
       <Icon class="material-icons">{icons[type]}</Icon>
@@ -71,5 +72,23 @@
 
   .content :global(p) {
     margin: 0;
+  }
+
+  .box-container.compact {
+    gap: 0.25rem;
+    padding: 0.5rem 0.75rem;
+    border-left-width: 3px;
+  }
+
+  .box-container.compact :global(.icon) {
+    font-size: 1rem;
+  }
+
+  .box-container.compact .content {
+    font-size: 0.85rem;
+  }
+
+  .box-container.compact .box-content {
+    gap: 0.35rem;
   }
 </style>


### PR DESCRIPTION
Apply Default Preview Behavior:

 

Member Selection:

Dialog pre-selects members based on context:
Single-member apply: the specific member is pre-selected (enabled)
Apply-all: only configured/mandatory members are pre-selected (disabled members are unchecked)
Users can manually toggle any member before confirming
Members with no available default are shown as disabled (non-interactive)
Overwrite Detection:

Warning card appears below each member when:
The member's toggle is enabled AND
The member currently has an existing reference
Warning shows: "Overwrites current reference: [current-reference-id]"
Application:

On confirm, only selected members receive the new default
Unselected members keep their current references unchanged
Confirm button shows count: "Apply (3)" or "Close" if none selected


<img width="1840" height="1193" alt="image" src="https://github.com/user-attachments/assets/602392fd-3390-46ee-836c-5ab21ea1135e" />

<img width="1780" height="554" alt="image" src="https://github.com/user-attachments/assets/e348dfaa-cea0-4e6f-b919-c2e0a896a0ce" />
