### PR TITLE
fix(tsld): enable ESM module system, add preview target

### DIFF
--- a/apps/tsld/project.json
+++ b/apps/tsld/project.json
@@ -21,6 +21,14 @@
         "command": "vite",
         "cwd": "apps/tsld/src"
       }
+    },
+    "preview": {
+      "executor": "nx:run-commands",
+      "dependsOn": ["build"],
+      "options": {
+        "command": "vite preview",
+        "cwd": "apps/tsld"
+      }
     }
   }
 }

--- a/apps/tsld/src/OscdTsldEditor.ts
+++ b/apps/tsld/src/OscdTsldEditor.ts
@@ -1,9 +1,9 @@
-import {css, html, LitElement, TemplateResult} from 'lit';
+import {css, html, LitElement, type TemplateResult} from 'lit';
 import {property} from 'lit/decorators.js';
 import Cytoscape, {
-  ElementsDefinition,
-  NodeDefinition,
-  EdgeDefinition,
+  type ElementsDefinition,
+  type NodeDefinition,
+  type EdgeDefinition,
 } from 'cytoscape';
 import {
   circuitBreakerIcon,
@@ -58,13 +58,26 @@ export default class OscdTsldEditor extends LitElement {
     this.initializeCytoscape();
   }
 
+  protected override updated(changedProperties: Map<string, unknown>) {
+    if (changedProperties.has('doc')) {
+      this.initializeCytoscape();
+    }
+  }
+
   initializeCytoscape(): void {
+    const container = this.shadowRoot?.getElementById('cy');
+    if (!container || !this.doc) {
+      return;
+    }
+
+    this.cy?.destroy();
+
     const graph = this.createNodesEdges();
     const {nodes} = graph;
     const {edges} = graph;
 
     this.cy = Cytoscape({
-      container: this.shadowRoot?.getElementById('cy') as HTMLElement,
+      container: container as HTMLElement,
       elements: {
         nodes,
         edges,
@@ -169,16 +182,25 @@ export default class OscdTsldEditor extends LitElement {
   }
 
   createNodesEdges() {
+    const nodes: NodeDefinition[] = [];
+    const edges: EdgeDefinition[] = [];
+
+    if (!this.doc) {
+      return {nodes, edges};
+    }
+
     const substations = this.doc.querySelectorAll('Substation');
     const nodeListIED = this.doc.querySelectorAll('IED');
 
+    if (substations.length === 0) {
+      return {nodes, edges};
+    }
+
     const substationElement = substations.item(0);
     const nsAttribute = OscdTsldEditor.findCordAttribute(substationElement);
-    this.namespace = this.doc.lookupNamespaceURI(nsAttribute) as string;
-    const nms = this.namespace
-
-    const nodes: NodeDefinition[] = [];
-    const edges: EdgeDefinition[] = [];
+    this.namespace =
+      (nsAttribute && this.doc.lookupNamespaceURI(nsAttribute)) ?? '';
+    const nms = this.namespace || null;
 
     let offsetX = 0;
     let offsetY = 0;
@@ -842,7 +864,11 @@ export default class OscdTsldEditor extends LitElement {
     return (+baseX + +offsetX + +furthestIedX) * 50;
   }
 
-  static findCordAttribute(substationElement: Element) {
+  static findCordAttribute(substationElement: Element | null): string | null {
+    if (!substationElement) {
+      return null;
+    }
+
     const regex = /[se](xy|sld):x|x/y;
     const regexY = /[se](xy|sld):y|y/y;
     const matchx = Array.from(substationElement.attributes).find(i =>
@@ -853,10 +879,10 @@ export default class OscdTsldEditor extends LitElement {
     );
 
     if (matchx === undefined || matchy === undefined) {
-      throw new Error('one of the x/y attributes is undefined');
-    } else {
-      return matchx.name.split(':')[0];
+      return null;
     }
+
+    return matchx.name.split(':')[0];
   }
 
   override render(): TemplateResult {

--- a/apps/tsld/src/icons.ts
+++ b/apps/tsld/src/icons.ts
@@ -1,4 +1,4 @@
-import { html, svg, SVGTemplateResult, TemplateResult } from 'lit';
+import { html, svg, type SVGTemplateResult, type TemplateResult } from 'lit';
 
 export type iconType =
   | 'action'

--- a/apps/tsld/tsconfig.json
+++ b/apps/tsld/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "esnext",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
     "noImplicitOverride": true,

--- a/apps/tsld/vite.config.ts
+++ b/apps/tsld/vite.config.ts
@@ -4,9 +4,22 @@ import dts from 'vite-plugin-dts';
 import * as path from 'path';
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 
+const devPort = Number(process.env.TSLD_DEV_PORT ?? 5173);
+const previewPort = Number(process.env.TSLD_PREVIEW_PORT ?? 4300);
+
 export default defineConfig({
   root: __dirname,
   cacheDir: '../../node_modules/.vite/apps/tsld',
+
+  server: {
+    port: devPort,
+    host: 'localhost',
+  },
+
+  preview: {
+    port: previewPort,
+    host: 'localhost',
+  },
 
   plugins: [
     nxViteTsPaths(),


### PR DESCRIPTION
- Switch from CommonJS to ESM in tsconfig to resolve TS1295/TS1484 errors
- Use type-only imports for Lit and Cytoscape types under verbatimModuleSyntax
- Add preview target in project.json with configurable ports via env vars
- Add dev/preview port configuration in vite.config.ts (TSLD_DEV_PORT, TSLD_PREVIEW_PORT)
- Guard against null Substation elements to prevent runtime crashes
- Support document updates via Lit lifecycle hook (updated())
- Gracefully handle empty or invalid SCL documents instead of throwing