### PR TITLE
fix(template): add mandatory members on create data type (#OPENSCD-331)

### DIFF
--- a/apps/template-generator/src/features/type-details/services/type.service.spec.ts
+++ b/apps/template-generator/src/features/type-details/services/type.service.spec.ts
@@ -482,14 +482,29 @@ describe('DataTypeService', () => {
 	});
 
 	describe('create', () => {
-		test('creates DataTypeTemplates when missing and inserts first type', () => {
+		test('creates DataTypeTemplates when missing, inserts first type, and adds mandatory children', () => {
 			doc = parseScl(`
 				<SCL xmlns="http://www.iec.ch/61850/2003/SCL" version="2007" revision="B"/>
 			`);
 
 			service = new DataTypeService(doc, hostElement);
 			(service as any).nsdSchemaRegistry = {
-				getTypeDefinition: vi.fn(() => ({})),
+				getTypeDefinition: vi.fn(() => ({
+					stVal: {
+						tagName: 'DO',
+						name: 'stVal',
+						requiresReference: true,
+						isMandatory: true,
+						attributes: {},
+					},
+					q: {
+						tagName: 'DO',
+						name: 'q',
+						requiresReference: false,
+						isMandatory: false,
+						attributes: {},
+					},
+				})),
 				listInstanceTypes: vi.fn(() => []),
 			};
 
@@ -500,6 +515,58 @@ describe('DataTypeService', () => {
 
 			expect(doc.querySelector('DataTypeTemplates > DOType[id="new-do"]')).not.toBeNull();
 			expect(doc.querySelector('DOType[id="new-do"]')?.getAttribute('cdc')).toBe('SPS');
+			expect(doc.querySelector('DOType[id="new-do"] > DO[name="stVal"]')).not.toBeNull();
+			expect(doc.querySelector('DOType[id="new-do"] > DO[name="stVal"]')?.getAttribute('type')).toBeNull();
+			expect(doc.querySelector('DOType[id="new-do"] > DO[name="q"]')).toBeNull();
+		});
+
+		test('creates DOType SPS with all mandatory objects as children', () => {
+			doc = parseScl(`
+				<SCL xmlns="http://www.iec.ch/61850/2003/SCL" version="2007" revision="B">
+					<DataTypeTemplates/>
+				</SCL>
+			`);
+
+			service = new DataTypeService(doc, hostElement);
+			(service as any).nsdSchemaRegistry = {
+				getTypeDefinition: vi.fn(() => ({
+					stVal: {
+						tagName: 'DO',
+						name: 'stVal',
+						requiresReference: true,
+						refTypeKind: TypeKind.DOType,
+						objectType: 'SPS',
+						isMandatory: true,
+						attributes: {},
+					},
+					q: {
+						tagName: 'DO',
+						name: 'q',
+						requiresReference: false,
+						isMandatory: true,
+						attributes: {},
+					},
+					optionalDo: {
+						tagName: 'DO',
+						name: 'optionalDo',
+						requiresReference: false,
+						isMandatory: false,
+						attributes: {},
+					},
+				})),
+				listInstanceTypes: vi.fn(() => []),
+			};
+
+			service.create(TypeKind.DOType, 'SPS', 'do-sps');
+
+			expect(capturedEdits).toHaveLength(1);
+			capturedEdits.forEach(edit => handleEditV2(edit));
+
+			expect(doc.querySelector('DOType[id="do-sps"]')?.getAttribute('cdc')).toBe('SPS');
+			expect(doc.querySelector('DOType[id="do-sps"] > DO[name="stVal"]')).not.toBeNull();
+			expect(doc.querySelector('DOType[id="do-sps"] > DO[name="stVal"]')?.getAttribute('type')).toBeNull();
+			expect(doc.querySelector('DOType[id="do-sps"] > DO[name="q"]')).not.toBeNull();
+			expect(doc.querySelector('DOType[id="do-sps"] > DO[name="optionalDo"]')).toBeNull();
 		});
 	});
 

--- a/apps/template-generator/src/features/type-details/services/type.service.ts
+++ b/apps/template-generator/src/features/type-details/services/type.service.ts
@@ -549,6 +549,8 @@ export class DataTypeService {
      *
      * If `DataTypeTemplates` does not exist, it is created first and inserted into
      * the SCL root element with the new type as its first child.
+     * 
+     * All mandatory objects of the data type are created as empty elements, but without references configured.
      *
      * If `DataTypeTemplates` already exists, the new type is inserted in kind order:
      * `LNodeType -> DOType -> DAType -> EnumType`.
@@ -566,6 +568,7 @@ export class DataTypeService {
         }
 
         const newTypeElement = this.createDataTypeElement(typeKind, instanceType, id);
+        this.appendMandatoryMembers(newTypeElement, typeKind, instanceType);
         const title = `Create DataType ${id}`;
 
         const dataTypeTemplates = findDataTypeTemplatesElement(this.doc);
@@ -584,6 +587,19 @@ export class DataTypeService {
             title,
             createHistoryEntry: true,
         });
+    }
+
+    private appendMandatoryMembers(typeElement: Element, typeKind: TypeKind, instanceType: string): void {
+        const nsdDefinitions = this.nsdSchemaRegistry.getTypeDefinition(typeKind, instanceType);
+        if (!nsdDefinitions) {
+            return;
+        }
+
+        Object.entries(nsdDefinitions)
+            .filter(([, definition]) => definition.isMandatory)
+            .forEach(([memberName, definition]) => {
+                typeElement.appendChild(this.createMemberElement(memberName, definition));
+            });
     }
 
     /**


### PR DESCRIPTION
**Description**
Currently, creating a new Data Type results in an empty object (no children) in the SCD.
Mandatory elements are only added after the user configures additional elements.

**Expected Behavior**
Mandatory elements should be created by default when a new Data Type is created, even if no further configuration is done.

**Steps to Reproduce**

1. Create DO Type (e.g. SPS)
2. Do not configure any elements (only mandatory)
3. Save
**Actual Result**
Mandatory elements are missing in the SCD.

**Expected Result**
Mandatory elements are present in the SCD after save.