### PR TITLE
fix: remove arial labels from TList

### DIFF
--- a/apps/template-generator/src/features/type-details/components/tboard/TCardList.svelte
+++ b/apps/template-generator/src/features/type-details/components/tboard/TCardList.svelte
@@ -113,7 +113,7 @@
     dropAnimationDisabled: true,
     dropTargetStyle: {},
     type: dragAndDropType,
-
+    autoAriaDisabled: true // disable arial so that child elements, e.g. Add Reference button, can be accessible
   }}
   onconsider={e => handleListConsider(e)}
   onfinalize={e => handleListFinalize(e)}
@@ -124,7 +124,8 @@
                items: [item],
                dragDisabled: true,
                dropAnimationDisabled: true,
-              dropTargetStyle: {},
+               dropTargetStyle: {},
+               autoAriaDisabled: true, // disable arial so that child elements, e.g. Add Reference button, can be accessible
               type: dragAndDropType
              }}
          onconsider={e => handleDropConsider(e, item.id)}


### PR DESCRIPTION
Non-Draggable lists automatically get the arial label `arial-disabled`. Currently this affect child elements like the 'Add Reference' Button, that will be also disabled subsequently, although it should be enabled.

This makes it impossible for E2E tests to work. 

This change:
- removes arial labels from TList
- this prevents that arial-disabled to be
- Child elements are enabled subsequently