### PR TITLE
fix(archive): use location key to join archive resources

### DIFF
--- a/apps/archive-explorer/src/App.svelte
+++ b/apps/archive-explorer/src/App.svelte
@@ -74,13 +74,14 @@
   );
 
   // Fetch locations and store as Observable
+  // Archive search uses location.key for grouping and filtering
   const locations$ = locationService.listLocations().pipe(
     map(locs => {
-      const locMap = new Map(locs.map(l => [l.uuid, l.name]));
+      const locMap = new Map(locs.map(l => [l.key, l.name]));
       // Update filter options
       const locFilter = filterDefinitions.find(f => f.key === 'location');
       if (locFilter) {
-        locFilter.options = locs.map(loc => ({ value: loc.uuid, label: loc.name }));
+        locFilter.options = locs.map(loc => ({ value: loc.key, label: loc.name }));
       }
       locations = locMap;
       return locMap;
@@ -94,14 +95,20 @@
   );
 
 
+  function getLocationTitle(locationKey: string): string {
+    // Resolve location key to name; fallback to key or 'Unknown'
+    if (!locationKey) return 'Unknown';
+    return locations.get(locationKey) ?? locationKey ?? 'Unknown';
+  }
+
   function convertFilterToSearchParams(filters: FilterDefinition[], text: string): SearchParams {
     const searchParams: SearchParams = {
-      uuid: null,
-      type: null,
-      name: null,
-      location: null,
-      from: null,
-      to: null
+      uuid: undefined,
+      type: undefined,
+      name: undefined,
+      location: undefined,
+      from: undefined,
+      to: undefined
     };
 
     // Map filter values to searchParams
@@ -208,11 +215,11 @@
     {:else}
       {#if searchResults.size}
         {#each searchResults as result, index (result)}
-          <!-- result[0] => UUID of the location -->
+          <!-- result[0] => location key of the location -->
           <!-- result[1] => ArchiveSearchResult[] -->
           <OscdExpansionPanel
             open={true}
-            title={locations.get(result[0]) ?? 'Unknown'}
+            title={getLocationTitle(result[0])}
           >
             {#snippet content()}
               <span>

--- a/libs/oscd-archive-explorer/src/lib/services/archive-filter.service.ts
+++ b/libs/oscd-archive-explorer/src/lib/services/archive-filter.service.ts
@@ -55,13 +55,14 @@ export class ArchiveFilterService {
       this.locationService.listLocations().pipe(
         take(1),
         tap((locations) => {
-          const locationIdToNameMap = new Map<string, string>();
+          // Archive search uses location.key for grouping and filtering
+          const locationKeyToNameMap = new Map<string, string>();
 
           locations.forEach((location) => {
-            locationIdToNameMap.set(location.uuid, location.name);
+            locationKeyToNameMap.set(location.key, location.name);
           });
 
-          this.archiveExplorerLocationStore.updateData(locationIdToNameMap);
+          this.archiveExplorerLocationStore.updateData(locationKeyToNameMap);
         }),
         map((locations) => {
           return [
@@ -75,7 +76,7 @@ export class ArchiveFilterService {
                 validatorFn: () => true,
                 options:
                   locations?.map((location) => ({
-                    value: location.uuid,
+                    value: location.key,
                     label: location.name,
                   })) || [],
               },
@@ -91,6 +92,7 @@ export class ArchiveFilterService {
     return [
       {
         id: 2,
+        key: 'uuid',
         label: 'UUID',
         inputType: {
           id: 1,
@@ -102,6 +104,7 @@ export class ArchiveFilterService {
       },
       {
         id: 4,
+        key: 'approver',
         label: 'Approver',
         inputType: {
           id: 1,
@@ -113,6 +116,7 @@ export class ArchiveFilterService {
       },
       {
         id: 3,
+        key: 'type',
         label: 'Type',
         inputType: {
           id: 2,
@@ -131,35 +135,6 @@ export class ArchiveFilterService {
         },
         allowedOperations: ['='],
       },
-      // {
-      //   id: 4,
-      //   label: 'Type',
-      //   inputType: {
-      //     id: 2,
-      //     type: 'select',
-      //     validatorFn: () => true,
-      //     options: [
-      //       { value: 'Schütz', label: 'Schütz' },
-      //       { value: 'Leittechnik', label: 'Leittechnik' },
-      //     ],
-      //   },
-      //   allowedOperations: ['='],
-      // },
-      // {
-      //   id: 5,
-      //   label: 'Voltage',
-      //   inputType: {
-      //     id: 2,
-      //     type: 'select',
-      //     validatorFn: () => true,
-      //     options: [
-      //       { value: '380', label: '380' },
-      //       { value: '220', label: '220' },
-      //       { value: '110', label: '110' },
-      //     ],
-      //   },
-      //   allowedOperations: ['='],
-      // },
     ];
   }
 }

--- a/libs/oscd-archive-explorer/src/lib/services/location.service.ts
+++ b/libs/oscd-archive-explorer/src/lib/services/location.service.ts
@@ -26,29 +26,6 @@ export class LocationService {
       .getLocations({})
       .pipe(
         take(1),
-        catchError(() => {
-          // Dummy data until the service is implemented
-          return of([
-            {
-              uuid: '912e83a1-f84e-4d0d-9432-b5381e2b9e0d',
-              name: 'Location 1',
-              description: '',
-              key: '',
-            },
-            {
-              uuid: 'b9d01044-7bc7-4430-93b3-86ff093319e6',
-              name: 'Location 2',
-              description: '',
-              key: '',
-            },
-            {
-              uuid: 'f8435ba3-0c92-4ea3-ade0-5d72458c95c7',
-              name: 'Location 3',
-              description: '',
-              key: '',
-            },
-          ]);
-        })
       );
   }
 

--- a/libs/oscd-archive-explorer/src/lib/store/location-store.ts
+++ b/libs/oscd-archive-explorer/src/lib/store/location-store.ts
@@ -24,7 +24,10 @@ export class LocationStore {
     this.#data.set(data);
   }
 
-  public getLocationNameByUuid(uuid: string) {
-    return get(this.#data).get(uuid);
+  /**
+   * Get location name by key.
+   */
+  public getLocationNameByKey(key: string) {
+    return get(this.#data).get(key);
   }
 }


### PR DESCRIPTION
# Summary

This hotfix corrects how archive resources are joined to locations in the archive explorer.

The UI was resolving location names with UUID-based mapping, while archive search/version payloads provide the location key. Because of this mismatch, location panels could show Unknown even when locations were loaded correctly.

# What Changed
- Switched archive explorer location mapping from UUID to location key.
- Switched location filter option values from UUID to location key so filter payloads align with backend expectations.
- Added a dedicated location title resolver in the UI to provide stable fallback behavior.
- Updated archive filter service mapping/storage to use location key consistently.
- Removed obsolete dummy location fallback data from the location service.
- Renamed location store lookup API from UUID wording to key wording.

# Why This Fix Works
Archive search and version data identify locations by key. By using key-based mapping end-to-end (filter values, lookup map, and panel title resolution), the UI now resolves location names with the same identifier used by the backend responses.

# Impact
1. Fixes incorrect Unknown location headers in archive explorer panels.
2. Aligns filter requests with backend contract for location.

# Testing
1. Verified changes in archive explorer UI mapping and grouping flow.
